### PR TITLE
more app config renaming, renamed input_document_id to bundle for task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle/
 .idea/
 out/
+build/

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -49,7 +49,7 @@ module "app" {
     #DM STORE
     DM_STORE_APP_URL = "http://${var.dm_store_app_url}-${local.local_env}.service.core-compute-${local.local_env}.internal"
     #EM ANN API
-    EM_ANNO_APP_URL = "http://${var.em_anno_app_url}-${local.local_env}.service.core-compute-${local.local_env}.internal"
+    EM_STITCHING_API_URL = "http://${var.em_stitching_api_url}-${local.local_env}.service.core-compute-${local.local_env}.internal"
 
     # logging vars & healthcheck
     REFORM_SERVICE_NAME = "${local.app_full_name}"

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -33,6 +33,6 @@ output "dm_store_app_url" {
   value = "http://${var.dm_store_app_url}-${local.local_env}.service.core-compute-${local.local_env}.internal"
 }
 
-output "em_anno_app_url" {
-  value = "http://${var.em_anno_app_url}-${local.local_env}.service.core-compute-${local.local_env}.internal"
+output "em_stitching_api_url" {
+  value = "http://${var.em_stitching_api_url}-${local.local_env}.service.core-compute-${local.local_env}.internal"
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -68,8 +68,8 @@ variable "dm_store_app_url" {
   default = "dm-store"
 }
 
-variable "em_anno_app_url" {
-  default = "em-anno"
+variable "em_stitching_api_url" {
+  default = "em-stitching"
 }
 
 variable "postgresql_user" {

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
@@ -35,7 +35,7 @@ public class DocumentTaskScenarios {
 
         UUID nonExistentDocumentId = UUID.randomUUID();
         JSONObject jsonObject = new JSONObject();
-        jsonObject.put("inputDocumentId", nonExistentDocumentId);
+        jsonObject.put("bundle", nonExistentDocumentId);
 
         testUtil
             .authRequest()
@@ -44,7 +44,7 @@ public class DocumentTaskScenarios {
                 .request("POST", Env.getTestUrl() + "/api/document-tasks")
             .then()
                 .statusCode(201)
-                .body("inputDocumentId", equalTo(nonExistentDocumentId.toString()))
+                .body("bundle", equalTo(nonExistentDocumentId.toString()))
                 .body("taskState", equalTo(TaskState.FAILED.toString()))
                 .body("failureDescription", equalTo("Could not access the binary. HTTP response: 404"));
 
@@ -56,7 +56,7 @@ public class DocumentTaskScenarios {
         String newDocId = testUtil.uploadDocument();
 
         JSONObject jsonObject = new JSONObject();
-        jsonObject.put("inputDocumentId", newDocId);
+        jsonObject.put("bundle", newDocId);
 
         testUtil
             .authRequest()
@@ -65,7 +65,7 @@ public class DocumentTaskScenarios {
                 .request("POST", Env.getTestUrl() + "/api/document-tasks")
             .then()
                 .statusCode(201)
-                .body("inputDocumentId", equalTo(newDocId))
+                .body("bundle", equalTo(newDocId))
                 .body("taskState", equalTo(TaskState.FAILED.toString()))
                 .body("failureDescription", startsWith("Could not access the annotation set."));
 
@@ -79,7 +79,7 @@ public class DocumentTaskScenarios {
         testUtil.createAnnotationSetForDocumentId(newDocId);
 
         JSONObject jsonObject = new JSONObject();
-        jsonObject.put("inputDocumentId", newDocId);
+        jsonObject.put("bundle", newDocId);
 
         testUtil.authRequest()
             .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
@@ -87,7 +87,7 @@ public class DocumentTaskScenarios {
             .request("POST", Env.getTestUrl() + "/api/document-tasks")
             .then()
             .statusCode(201)
-            .body("inputDocumentId", equalTo(newDocId))
+            .body("bundle", equalTo(newDocId))
             .body("taskState", equalTo(TaskState.DONE.toString()));
 
     }
@@ -102,7 +102,7 @@ public class DocumentTaskScenarios {
         testUtil.saveAnnotation(annotationSetId);
 
         JSONObject jsonObject = new JSONObject();
-        jsonObject.put("inputDocumentId", newDocId);
+        jsonObject.put("bundle", newDocId);
 
         Response response = testUtil.authRequest()
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
@@ -110,7 +110,7 @@ public class DocumentTaskScenarios {
                 .request("POST", Env.getTestUrl() + "/api/document-tasks");
 
         Assert.assertEquals(201, response.getStatusCode());
-        Assert.assertEquals( response.getBody().jsonPath().getString("inputDocumentId"), newDocId);
+        Assert.assertEquals( response.getBody().jsonPath().getString("bundle"), newDocId);
         Assert.assertEquals( response.getBody().jsonPath().getString("taskState"), TaskState.DONE.toString());
 
         File file = testUtil.getDocumentBinary(response.getBody().jsonPath().getString("outputDocumentId"));

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/performance/NpaLoad.scala
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/performance/NpaLoad.scala
@@ -12,7 +12,7 @@ class NpaLoad extends Simulation with HttpConfiguration {
 
   object CreateTask {
 
-    var jsonObject = new JSONObject().put("inputDocumentId", testUtil.getDocumentId).toString()
+    var jsonObject = new JSONObject().put("bundle", testUtil.getDocumentId).toString()
     def run = exec(
           http("create-npa-task-" + testConfig.pdfName)
             .post(Env.getTestUrl + "/api/document-tasks")
@@ -21,7 +21,7 @@ class NpaLoad extends Simulation with HttpConfiguration {
             .body(StringBody(jsonObject))
             .check(
               status.find.in(201),
-              jsonPath("$.inputDocumentId").exists,
+              jsonPath("$.bundle").exists,
               jsonPath("$.outputDocumentId").exists,
               jsonPath("$.taskState").in("DONE"),
               jsonPath("$").saveAs("RESPONSE_DATA")

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/testutil/Env.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/testutil/Env.java
@@ -17,7 +17,7 @@ public class Env {
         defaults.setProperty("IDAM_API_USER_ROLE", "caseworker");
         defaults.setProperty("IDAM_API_USER", "test@test.com");
         defaults.setProperty("IDAM_API_URL", "http://localhost:4501");
-        defaults.setProperty("EM_ANNO_APP_URL", "http://localhost:4623");
+        defaults.setProperty("EM_STITCHING_API_URL", "http://localhost:4623");
         defaults.setProperty("DM_STORE_APP_URL", "http://localhost:4603");
     }
 
@@ -43,8 +43,8 @@ public class Env {
         return require("S2S_SERVICE_NAME");
     }
 
-    public static String getAnnotationApiUrl() {
-        return require("EM_ANNO_APP_URL");
+    public static String getStitchingApiUrl() {
+        return require("EM_STITCHING_API_URL");
     }
 
     public static String getDmApiUrl() {

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/testutil/TestUtil.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/testutil/TestUtil.java
@@ -74,7 +74,7 @@ public class TestUtil {
         Response response = authRequest()
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                 .body(createAnnotations)
-                .request("POST", Env.getAnnotationApiUrl() + "/api/annotations");
+                .request("POST", Env.getStitchingApiUrl() + "/api/annotations");
 
         Assert.assertEquals(201, response.getStatusCode());
 
@@ -94,7 +94,7 @@ public class TestUtil {
         Response response = authRequest()
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                 .body(createAnnotationSet)
-                .request("POST", Env.getAnnotationApiUrl() + "/api/annotation-sets");
+                .request("POST", Env.getStitchingApiUrl() + "/api/annotation-sets");
 
         Assert.assertEquals(201, response.getStatusCode());
 

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/batch/DocumentTaskItemProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/batch/DocumentTaskItemProcessor.java
@@ -36,9 +36,9 @@ public class DocumentTaskItemProcessor implements ItemProcessor<DocumentTask, Do
 
         try {
 
-            File originalFile = dmStoreDownloader.downloadFile(item.getInputDocumentId());
+            File originalFile = dmStoreDownloader.downloadFile(item.getBundle());
 
-            AnnotationSetDTO annotationSetDTO = annotationSetFetcher.fetchAnnotationSet(item.getInputDocumentId(), item.getJwt());
+            AnnotationSetDTO annotationSetDTO = annotationSetFetcher.fetchAnnotationSet(item.getBundle(), item.getJwt());
 
             File annotatedPdf = pdfAnnotator.annotatePdf(originalFile, annotationSetDTO);
 

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/config/BatchConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/config/BatchConfiguration.java
@@ -58,7 +58,7 @@ public class BatchConfiguration {
 //            .rowMapper((rs, i) -> {
 //                DocumentTask documentTask = new DocumentTask();
 //                documentTask.setId(rs.getLong("id"));
-//                documentTask.setInputDocumentId(rs.getString("input_document_id"));
+//                documentTask.setBundle(rs.getString("input_document_id"));
 //                documentTask.setOutputDocumentId(rs.getString("output_document_id"));
 //                documentTask.setTaskState(TaskState.valueOf(rs.getString("task_state")));
 //                return documentTask;

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/DocumentTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/DocumentTask.java
@@ -21,8 +21,8 @@ public class DocumentTask extends AbstractAuditingEntity implements Serializable
     @SequenceGenerator(name = "sequenceGenerator")
     private Long id;
 
-    @Column(name = "input_document_id")
-    private String inputDocumentId;
+    @Column(name = "bundle")
+    private String bundle;
 
     @Column(name = "output_document_id")
     private String outputDocumentId;
@@ -46,17 +46,17 @@ public class DocumentTask extends AbstractAuditingEntity implements Serializable
         this.id = id;
     }
 
-    public String getInputDocumentId() {
-        return inputDocumentId;
+    public String getBundle() {
+        return bundle;
     }
 
-    public DocumentTask inputDocumentId(String inputDocumentId) {
-        this.inputDocumentId = inputDocumentId;
+    public DocumentTask bundle(String bundle) {
+        this.bundle = bundle;
         return this;
     }
 
-    public void setInputDocumentId(String inputDocumentId) {
-        this.inputDocumentId = inputDocumentId;
+    public void setBundle(String bundle) {
+        this.bundle = bundle;
     }
 
     public String getOutputDocumentId() {
@@ -123,7 +123,7 @@ public class DocumentTask extends AbstractAuditingEntity implements Serializable
     public String toString() {
         return "DocumentTask{" +
             "id=" + getId() +
-            ", inputDocumentId='" + getInputDocumentId() + "'" +
+            ", bundle='" + getBundle() + "'" +
             ", outputDocumentId='" + getOutputDocumentId() + "'" +
             ", taskState='" + getTaskState() + "'" +
             ", failureDescription='" + getFailureDescription() + "'" +

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/DocumentTaskDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/DocumentTaskDTO.java
@@ -15,7 +15,7 @@ public class DocumentTaskDTO extends AbstractAuditingDTO implements Serializable
     private Long id;
 
     @NotNull
-    private String inputDocumentId;
+    private String bundle;
 
     private String outputDocumentId;
 
@@ -34,12 +34,12 @@ public class DocumentTaskDTO extends AbstractAuditingDTO implements Serializable
         this.id = id;
     }
 
-    public String getInputDocumentId() {
-        return inputDocumentId;
+    public String getBundle() {
+        return bundle;
     }
 
-    public void setInputDocumentId(String inputDocumentId) {
-        this.inputDocumentId = inputDocumentId;
+    public void setBundle(String bundle) {
+        this.bundle = bundle;
     }
 
     public String getOutputDocumentId() {
@@ -99,7 +99,7 @@ public class DocumentTaskDTO extends AbstractAuditingDTO implements Serializable
     public String toString() {
         return "DocumentTaskDTO{" +
             "id=" + getId() +
-            ", inputDocumentId='" + getInputDocumentId() + "'" +
+            ", bundle='" + getBundle() + "'" +
             ", outputDocumentId='" + getOutputDocumentId() + "'" +
             ", taskState='" + getTaskState() + "'" +
             ", failureDescription='" + getFailureDescription() + "'" +

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/AnnotationSetFetcherImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/AnnotationSetFetcherImpl.java
@@ -32,7 +32,7 @@ public class AnnotationSetFetcherImpl implements AnnotationSetFetcher {
     public AnnotationSetFetcherImpl(OkHttpClient okHttpClient,
                                     AuthTokenGenerator authTokenGenerator,
                                     ObjectMapper objectMapper,
-                                    @Value("${em-annotation-app.base-url}") String annotationApiEndpointBase) {
+                                    @Value("${em-rpa-stitching-api.base-url}") String annotationApiEndpointBase) {
         this.okHttpClient = okHttpClient;
         this.annotationApiEndpointBase = annotationApiEndpointBase;
         this.authTokenGenerator = authTokenGenerator;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -105,8 +105,8 @@ app-insights:
   request-component: on
   telemetry-component: on
 
-em-annotation-app:
-  base-url: ${EM_ANNO_APP_URL:http://localhost:4623}
+em-rpa-stitching-api:
+  base-url: ${EM_STITCHING_API_URL:http://localhost:4623}
 
 dm-store-app:
   base-url: ${DM_STORE_APP_URL:http://localhost:4603}

--- a/src/main/resources/db/changelog/20180918132136_added_entity_DocumentTask.xml
+++ b/src/main/resources/db/changelog/20180918132136_added_entity_DocumentTask.xml
@@ -21,8 +21,8 @@
             <column name="id" type="bigint" autoIncrement="${autoIncrement}">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="input_document_id" type="varchar(255)">
-                <constraints nullable="true" />
+            <column name="bundle" type="text">
+                <constraints nullable="false" />
             </column>
 
             <column name="output_document_id" type="varchar(255)">

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/batch/DocumentTaskItemProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/batch/DocumentTaskItemProcessorTest.java
@@ -28,7 +28,7 @@ public class DocumentTaskItemProcessorTest {
         String docId = "X";
 
         DocumentTask documentTask = new DocumentTask();
-        documentTask.setInputDocumentId(docId);
+        documentTask.setBundle(docId);
 
         Mockito.when(dmStoreDownloader.downloadFile(docId)).thenThrow(new DocumentTaskProcessingException("problem"));
 

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResourceIntTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResourceIntTest.java
@@ -96,8 +96,8 @@ public class DocumentTaskResourceIntTest {
     @Value("${dm-store-app.base-url}")
     private String dmBaseUrl;
 
-    @Value("${em-annotation-app.base-url}")
-    private String emAnnotationAppBaseUrl;
+    @Value("${em-rpa-stitching-api.base-url}")
+    private String emStitchingAppBaseUrl;
 
     private MockMvc restDocumentTaskMockMvc;
 
@@ -124,7 +124,7 @@ public class DocumentTaskResourceIntTest {
      */
     public static DocumentTask createEntity(EntityManager em) {
         DocumentTask documentTask = new DocumentTask()
-            .inputDocumentId(DEFAULT_INPUT_DOCUMENT_ID)
+            .bundle(DEFAULT_INPUT_DOCUMENT_ID)
             .outputDocumentId(DEFAULT_OUTPUT_DOCUMENT_ID)
             .taskState(DEFAULT_TASK_STATE)
             .failureDescription(DEFAULT_FAILURE_DESCRIPTION);
@@ -150,7 +150,7 @@ public class DocumentTaskResourceIntTest {
         mockInterceptor.addRule(new Rule.Builder().get().url(dmBaseUrl + "/documents/AAAAAAAAAA/binary")
                 .respond(classLoader.getResourceAsStream("annotationTemplate.pdf")));
 
-        mockInterceptor.addRule(new Rule.Builder().get().url(emAnnotationAppBaseUrl + "/api/annotation-sets/filter?documentId=AAAAAAAAAA")
+        mockInterceptor.addRule(new Rule.Builder().get().url(emStitchingAppBaseUrl + "/api/annotation-sets/filter?documentId=AAAAAAAAAA")
                 .respond("{ \"annotations\" : [] }"));
 
         mockInterceptor.addRule(new Rule.Builder().post().url(dmBaseUrl + "/documents")
@@ -175,7 +175,7 @@ public class DocumentTaskResourceIntTest {
         List<DocumentTask> documentTaskList = documentTaskRepository.findAll();
         assertThat(documentTaskList).hasSize(databaseSizeBeforeCreate + 1);
         DocumentTask testDocumentTask = documentTaskList.get(documentTaskList.size() - 1);
-        assertThat(testDocumentTask.getInputDocumentId()).isEqualTo(DEFAULT_INPUT_DOCUMENT_ID);
+        assertThat(testDocumentTask.getBundle()).isEqualTo(DEFAULT_INPUT_DOCUMENT_ID);
         assertThat(testDocumentTask.getOutputDocumentId()).isEqualTo("new-doc_url");
         assertThat(testDocumentTask.getTaskState()).isEqualTo(TaskState.DONE);
         assertThat(testDocumentTask.getFailureDescription()).isEqualTo(DEFAULT_FAILURE_DESCRIPTION);
@@ -196,7 +196,7 @@ public class DocumentTaskResourceIntTest {
         DocumentTaskDTO documentTaskDTO = documentTaskMapper.toDto(documentTask);
         documentTaskDTO.setOutputDocumentId("BBBBBB");
 
-        mockInterceptor.addRule(new Rule.Builder().get().url(emAnnotationAppBaseUrl + "/api/annotation-sets/filter?documentId=AAAAAAAAAA")
+        mockInterceptor.addRule(new Rule.Builder().get().url(emStitchingAppBaseUrl + "/api/annotation-sets/filter?documentId=AAAAAAAAAA")
                 .respond("{ \"annotations\" : [{\"color\":\"ff0011\", \"page\": 1, \"rectangles\": [{\"x\":0, \"y\":0, \"width\":10, \"height\":\"10\"}]}] }"));
 
 
@@ -218,7 +218,7 @@ public class DocumentTaskResourceIntTest {
         List<DocumentTask> documentTaskList = documentTaskRepository.findAll();
         assertThat(documentTaskList).hasSize(databaseSizeBeforeCreate + 1);
         DocumentTask testDocumentTask = documentTaskList.get(documentTaskList.size() - 1);
-        assertThat(testDocumentTask.getInputDocumentId()).isEqualTo(DEFAULT_INPUT_DOCUMENT_ID);
+        assertThat(testDocumentTask.getBundle()).isEqualTo(DEFAULT_INPUT_DOCUMENT_ID);
         assertThat(testDocumentTask.getOutputDocumentId()).isEqualTo(documentTaskDTO.getOutputDocumentId());
         assertThat(testDocumentTask.getTaskState()).isEqualTo(TaskState.DONE);
         assertThat(testDocumentTask.getFailureDescription()).isEqualTo(DEFAULT_FAILURE_DESCRIPTION);
@@ -255,7 +255,7 @@ public class DocumentTaskResourceIntTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$.[*].id").value(hasItem(documentTask.getId().intValue())))
-            .andExpect(jsonPath("$.[*].inputDocumentId").value(hasItem(DEFAULT_INPUT_DOCUMENT_ID.toString())))
+            .andExpect(jsonPath("$.[*].bundle").value(hasItem(DEFAULT_INPUT_DOCUMENT_ID.toString())))
             .andExpect(jsonPath("$.[*].outputDocumentId").value(hasItem(DEFAULT_OUTPUT_DOCUMENT_ID.toString())))
             .andExpect(jsonPath("$.[*].taskState").value(hasItem(DEFAULT_TASK_STATE.toString())))
             .andExpect(jsonPath("$.[*].failureDescription").value(hasItem(DEFAULT_FAILURE_DESCRIPTION.toString())));
@@ -272,7 +272,7 @@ public class DocumentTaskResourceIntTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(jsonPath("$.id").value(documentTask.getId().intValue()))
-            .andExpect(jsonPath("$.inputDocumentId").value(DEFAULT_INPUT_DOCUMENT_ID.toString()))
+            .andExpect(jsonPath("$.bundle").value(DEFAULT_INPUT_DOCUMENT_ID.toString()))
             .andExpect(jsonPath("$.outputDocumentId").value(DEFAULT_OUTPUT_DOCUMENT_ID.toString()))
             .andExpect(jsonPath("$.taskState").value(DEFAULT_TASK_STATE.toString()))
             .andExpect(jsonPath("$.failureDescription").value(DEFAULT_FAILURE_DESCRIPTION.toString()));
@@ -300,7 +300,7 @@ public class DocumentTaskResourceIntTest {
         // Disconnect from session so that the updates on updatedDocumentTask are not directly saved in db
         em.detach(updatedDocumentTask);
         updatedDocumentTask
-            .inputDocumentId(UPDATED_INPUT_DOCUMENT_ID)
+            .bundle(UPDATED_INPUT_DOCUMENT_ID)
             .outputDocumentId(UPDATED_OUTPUT_DOCUMENT_ID)
             .taskState(UPDATED_TASK_STATE)
             .failureDescription(UPDATED_FAILURE_DESCRIPTION);
@@ -315,7 +315,7 @@ public class DocumentTaskResourceIntTest {
         List<DocumentTask> documentTaskList = documentTaskRepository.findAll();
         assertThat(documentTaskList).hasSize(databaseSizeBeforeUpdate);
         DocumentTask testDocumentTask = documentTaskList.get(documentTaskList.size() - 1);
-        assertThat(testDocumentTask.getInputDocumentId()).isEqualTo(UPDATED_INPUT_DOCUMENT_ID);
+        assertThat(testDocumentTask.getBundle()).isEqualTo(UPDATED_INPUT_DOCUMENT_ID);
         assertThat(testDocumentTask.getOutputDocumentId()).isEqualTo(UPDATED_OUTPUT_DOCUMENT_ID);
         assertThat(testDocumentTask.getTaskState()).isEqualTo(UPDATED_TASK_STATE);
         assertThat(testDocumentTask.getFailureDescription()).isEqualTo(UPDATED_FAILURE_DESCRIPTION);


### PR DESCRIPTION
The DocumentTask structure is very similar to what we will need for the stitching task. I've renamed input_document_id to bundle and made it a generic text field, although we might want to set it to JSON later. 

I've also renamed a few more instances of annotation to stitching.

There is still a lot that needs to be removed. I'll get started on that next.