### PR TITLE
Add synchronous endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
@@ -30,9 +30,11 @@ public class Bundle extends AbstractAuditingEntity implements Serializable {
     private String comments;
 
     @ElementCollection
+    @OneToMany(cascade=CascadeType.ALL)
     private List<BundleFolder> folders;
 
     @ElementCollection
+    @OneToMany(cascade=CascadeType.ALL)
     private List<BundleDocument> documents;
 
     private String orderFoldersBy;

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/BundleDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/BundleDocument.java
@@ -14,7 +14,7 @@ public class BundleDocument extends AbstractAuditingEntity implements Serializab
     @SequenceGenerator(name = "sequenceGenerator")
     private Long id;
 
-    private Long documentId;
+    private String documentId;
     private String docTitle;
     private String docDescription;
     private String documentURI;
@@ -32,11 +32,11 @@ public class BundleDocument extends AbstractAuditingEntity implements Serializab
         this.id = id;
     }
 
-    public Long getDocumentId() {
+    public String getDocumentId() {
         return documentId;
     }
 
-    public void setDocumentId(Long documentId) {
+    public void setDocumentId(String documentId) {
         this.documentId = documentId;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/DocumentTaskService.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/DocumentTaskService.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.em.stitching.service;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import uk.gov.hmcts.reform.em.stitching.service.dto.DocumentTaskDTO;
 
 import java.util.Optional;
@@ -20,15 +18,6 @@ public interface DocumentTaskService {
     DocumentTaskDTO save(DocumentTaskDTO documentTaskDTO);
 
     /**
-     * Get all the documentTasks.
-     *
-     * @param pageable the pagination information
-     * @return the list of entities
-     */
-    Page<DocumentTaskDTO> findAll(Pageable pageable);
-
-
-    /**
      * Get the "id" documentTask.
      *
      * @param id the id of the entity
@@ -37,9 +26,11 @@ public interface DocumentTaskService {
     Optional<DocumentTaskDTO> findOne(Long id);
 
     /**
-     * Delete the "id" documentTask.
+     * Process a document task
      *
-     * @param id the id of the entity
+     * @param documentTaskDTO task to process
+     * @return updated dto
      */
-    void delete(Long id);
+    DocumentTaskDTO process(DocumentTaskDTO documentTaskDTO);
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/BundleDocumentDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/BundleDocumentDTO.java
@@ -14,8 +14,7 @@ public class BundleDocumentDTO extends AbstractAuditingDTO implements Serializab
     @SequenceGenerator(name = "sequenceGenerator")
     private Long id;
 
-    @JsonIgnore
-    private Long documentId;
+    private String documentId;
     private String docTitle;
     private String docDescription;
     private String documentURI;
@@ -33,11 +32,11 @@ public class BundleDocumentDTO extends AbstractAuditingDTO implements Serializab
         this.id = id;
     }
 
-    public Long getDocumentId() {
+    public String getDocumentId() {
         return documentId;
     }
 
-    public void setDocumentId(Long documentId) {
+    public void setDocumentId(String documentId) {
         this.documentId = documentId;
     }
 

--- a/src/main/resources/db/db.changelog-master.xml
+++ b/src/main/resources/db/db.changelog-master.xml
@@ -53,7 +53,7 @@
             <column name="date_added_to_case" type="TIMESTAMP WITHOUT TIME ZONE"/>
             <column name="doc_description" type="VARCHAR(255)"/>
             <column name="doc_title" type="VARCHAR(255)"/>
-            <column name="document_id" type="BIGINT"/>
+            <column name="document_id" type="VARCHAR(255)"/>
             <column name="documenturi" type="VARCHAR(255)"/>
             <column name="is_included_in_bundle" type="BOOLEAN">
                 <constraints nullable="false"/>

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/BundleTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/BundleTest.java
@@ -8,12 +8,16 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
 
 public class BundleTest {
-    private ObjectMapper mapper = new ObjectMapper();
+    private static final String DEFAULT_DOCUMENT_ID = "AAAAAAAAAA";
+
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Before
     public void setup() {
@@ -33,12 +37,16 @@ public class BundleTest {
     }
 
     public static Bundle getTestBundle() {
+        BundleDocument bundleDocument = new BundleDocument();
+        bundleDocument.setDocumentId(DEFAULT_DOCUMENT_ID);
+
         Bundle bundle = new Bundle();
         bundle.setBundleTitle("My bundle");
         bundle.setVersion(1);
         bundle.setDescription("Bundle description");
         bundle.setCreatedDate(Instant.parse("2019-01-09T14:00:00Z"));
         bundle.setCreatedBy("Billy Bob");
+        bundle.setDocuments(Collections.singletonList(bundleDocument));
 
         return bundle;
 

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImplTest.java
@@ -11,9 +11,7 @@ import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
 import uk.gov.hmcts.reform.em.stitching.service.DmStoreDownloader;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -29,8 +27,8 @@ public class DmStoreDownloaderImplTest {
     public void downloadFile() throws Exception {
         BundleDocument mockBundleDocument1 = new BundleDocument();
         BundleDocument mockBundleDocument2 = new BundleDocument();
-        mockBundleDocument1.setDocumentId(1L);
-        mockBundleDocument2.setDocumentId(2L);
+        mockBundleDocument1.setDocumentId("AAAA");
+        mockBundleDocument2.setDocumentId("BBBB");
         Stream<File> results = dmStoreDownloader.downloadFiles(Arrays.asList(mockBundleDocument1, mockBundleDocument2));
 
         results.collect(Collectors.toList());


### PR DESCRIPTION
This PR introduces a synchronous version of the stitching endpoint. It also changes the type of `documentId` to `String`.