### PR TITLE
Clean up

### DIFF
--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
@@ -35,7 +35,7 @@ public class DocumentTaskScenarios {
         Response getTaskResponse = testUtil.pollUntil(taskUrl, body -> body.getString("taskState").equals("DONE"));
 
         Assert.assertEquals(200, getTaskResponse.getStatusCode());
-        Assert.assertNotNull(getTaskResponse.getBody().jsonPath().getString("bundle.stitchedDocId"));
+        Assert.assertNotNull(getTaskResponse.getBody().jsonPath().getString("bundle.stitchedDocumentURI"));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class DocumentTaskScenarios {
         Response getTaskResponse = testUtil.pollUntil(taskUrl, body -> body.getString("taskState").equals("DONE"));
 
         Assert.assertEquals(200, getTaskResponse.getStatusCode());
-        Assert.assertNotNull(getTaskResponse.getBody().jsonPath().getString("bundle.stitchedDocId"));
+        Assert.assertNotNull(getTaskResponse.getBody().jsonPath().getString("bundle.stitchedDocumentURI"));
     }
 
     @Test

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/testutil/TestUtil.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/testutil/TestUtil.java
@@ -49,7 +49,7 @@ public class TestUtil {
             .jsonPath()
             .get("_embedded.documents[0]._links.self.href");
 
-        return newDocUrl;
+        return newDocUrl.replace(Env.getDmApiUrl(), "");
     }
 
     public String uploadDocument() {
@@ -184,7 +184,7 @@ public class TestUtil {
             .jsonPath()
             .get("_embedded.documents[0]._links.self.href");
 
-        return newDocUrl;
+        return newDocUrl.replace(Env.getDmApiUrl(), "");
     }
 
     public String uploadDocX(String docName) {
@@ -197,7 +197,7 @@ public class TestUtil {
             .jsonPath()
             .get("_embedded.documents[0]._links.self.href");
 
-        return newDocUrl;
+        return newDocUrl.replace(Env.getDmApiUrl(), "");
     }
 
     public Response pollUntil(String endpoint, Function<JsonPath, Boolean> evaluator) throws InterruptedException, IOException {

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/testutil/TestUtil.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/testutil/TestUtil.java
@@ -153,10 +153,8 @@ public class TestUtil {
     }
 
     public BundleDocumentDTO getTestBundleDocument(String documentUrl) {
-        String documentId = documentUrl.substring(documentUrl.lastIndexOf("/") + 1);
         BundleDocumentDTO document = new BundleDocumentDTO();
 
-        document.setDocumentId(documentId);
         document.setDocumentURI(documentUrl);
 
         return document;

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/config/Constants.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/config/Constants.java
@@ -7,7 +7,6 @@ public final class Constants {
 
     public static final String SYSTEM_ACCOUNT = "system";
     public static final String ANONYMOUS_USER = "anonymoususer";
-    public static final String DEFAULT_LANGUAGE = "en";
 
     private Constants() {
     }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
@@ -13,24 +13,15 @@ import java.util.stream.Stream;
 @Table(name = "bundle")
 public class Bundle extends AbstractAuditingEntity implements SortableBundleItem, Serializable {
 
-
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
     @SequenceGenerator(name = "sequenceGenerator")
     private Long id;
 
     private String bundleTitle;
-    private int version;
     private String description;
-    private String purpose;
-    private String stitchedDocId;
     private String stitchedDocumentURI;
     private String stitchStatus;
-    private boolean isLocked;
-    private Instant dateLocked;
-    private String lockedBy;
-    private String comments;
 
     @ElementCollection
     @OneToMany(cascade=CascadeType.ALL)
@@ -56,36 +47,12 @@ public class Bundle extends AbstractAuditingEntity implements SortableBundleItem
         this.bundleTitle = bundleTitle;
     }
 
-    public int getVersion() {
-        return version;
-    }
-
-    public void setVersion(int version) {
-        this.version = version;
-    }
-
     public String getDescription() {
         return description;
     }
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    public String getPurpose() {
-        return purpose;
-    }
-
-    public void setPurpose(String purpose) {
-        this.purpose = purpose;
-    }
-
-    public String getStitchedDocId() {
-        return stitchedDocId;
-    }
-
-    public void setStitchedDocId(String stitchedDocId) {
-        this.stitchedDocId = stitchedDocId;
     }
 
     public String getStitchedDocumentURI() {
@@ -102,38 +69,6 @@ public class Bundle extends AbstractAuditingEntity implements SortableBundleItem
 
     public void setStitchStatus(String stitchStatus) {
         this.stitchStatus = stitchStatus;
-    }
-
-    public boolean isLocked() {
-        return isLocked;
-    }
-
-    public void setLocked(boolean locked) {
-        isLocked = locked;
-    }
-
-    public Instant getDateLocked() {
-        return dateLocked;
-    }
-
-    public void setDateLocked(Instant dateLocked) {
-        this.dateLocked = dateLocked;
-    }
-
-    public String getLockedBy() {
-        return lockedBy;
-    }
-
-    public void setLockedBy(String lockedBy) {
-        this.lockedBy = lockedBy;
-    }
-
-    public String getComments() {
-        return comments;
-    }
-
-    public void setComments(String comments) {
-        this.comments = comments;
     }
 
     public List<BundleFolder> getFolders() {

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/BundleDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/BundleDocument.java
@@ -14,13 +14,9 @@ public class BundleDocument extends AbstractAuditingEntity implements SortableBu
     @SequenceGenerator(name = "sequenceGenerator")
     private Long id;
 
-    private String documentId;
     private String docTitle;
     private String docDescription;
     private String documentURI;
-    private Instant dateAddedToCase;
-    private boolean isIncludedInBundle;
-    private String creatorRole;
     private int sortIndex;
 
     public Long getId() {
@@ -29,14 +25,6 @@ public class BundleDocument extends AbstractAuditingEntity implements SortableBu
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-    public String getDocumentId() {
-        return documentId;
-    }
-
-    public void setDocumentId(String documentId) {
-        this.documentId = documentId;
     }
 
     public String getDocTitle() {
@@ -61,30 +49,6 @@ public class BundleDocument extends AbstractAuditingEntity implements SortableBu
 
     public void setDocumentURI(String documentURI) {
         this.documentURI = documentURI;
-    }
-
-    public Instant getDateAddedToCase() {
-        return dateAddedToCase;
-    }
-
-    public void setDateAddedToCase(Instant dateAddedToCase) {
-        this.dateAddedToCase = dateAddedToCase;
-    }
-
-    public String getCreatorRole() {
-        return creatorRole;
-    }
-
-    public void setCreatorRole(String creatorRole) {
-        this.creatorRole = creatorRole;
-    }
-
-    public boolean isIncludedInBundle() {
-        return isIncludedInBundle;
-    }
-
-    public void setIncludedInBundle(boolean includedInBundle) {
-        isIncludedInBundle = includedInBundle;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/DocumentTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/DocumentTask.java
@@ -31,7 +31,7 @@ public class DocumentTask extends AbstractAuditingEntity implements Serializable
     @Column(name = "failure_description")
     private String failureDescription;
 
-    @Column(name = "jwt", length = 500)
+    @Column(name = "jwt", length = 5000)
     private String jwt;
 
     public DocumentTask() {

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/BundleDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/BundleDTO.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.em.stitching.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,16 +11,9 @@ public class BundleDTO extends AbstractAuditingDTO implements Serializable {
     private Long id;
 
     private String bundleTitle;
-    private int version;
     private String description;
-    private String purpose;
-    private String stitchedDocId;
     private String stitchedDocumentURI;
     private String stitchStatus;
-    private boolean isLocked;
-    private Instant dateLocked;
-    private String lockedBy;
-    private String comments;
     private List<BundleFolderDTO> folders = new ArrayList<>();
     private List<BundleDocumentDTO> documents = new ArrayList<>();
 
@@ -41,36 +33,12 @@ public class BundleDTO extends AbstractAuditingDTO implements Serializable {
         this.bundleTitle = bundleTitle;
     }
 
-    public int getVersion() {
-        return version;
-    }
-
-    public void setVersion(int version) {
-        this.version = version;
-    }
-
     public String getDescription() {
         return description;
     }
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    public String getPurpose() {
-        return purpose;
-    }
-
-    public void setPurpose(String purpose) {
-        this.purpose = purpose;
-    }
-
-    public String getStitchedDocId() {
-        return stitchedDocId;
-    }
-
-    public void setStitchedDocId(String stitchedDocId) {
-        this.stitchedDocId = stitchedDocId;
     }
 
     public String getStitchedDocumentURI() {
@@ -87,38 +55,6 @@ public class BundleDTO extends AbstractAuditingDTO implements Serializable {
 
     public void setStitchStatus(String stitchStatus) {
         this.stitchStatus = stitchStatus;
-    }
-
-    public boolean isLocked() {
-        return isLocked;
-    }
-
-    public void setLocked(boolean locked) {
-        isLocked = locked;
-    }
-
-    public Instant getDateLocked() {
-        return dateLocked;
-    }
-
-    public void setDateLocked(Instant dateLocked) {
-        this.dateLocked = dateLocked;
-    }
-
-    public String getLockedBy() {
-        return lockedBy;
-    }
-
-    public void setLockedBy(String lockedBy) {
-        this.lockedBy = lockedBy;
-    }
-
-    public String getComments() {
-        return comments;
-    }
-
-    public void setComments(String comments) {
-        this.comments = comments;
     }
 
     public List<BundleFolderDTO> getFolders() {

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/BundleDocumentDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/BundleDocumentDTO.java
@@ -1,22 +1,17 @@
 package uk.gov.hmcts.reform.em.stitching.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import javax.persistence.*;
+
 import java.io.Serializable;
-import java.time.Instant;
 
 public class BundleDocumentDTO extends AbstractAuditingDTO implements Serializable {
 
     @JsonIgnore
     private Long id;
 
-    private String documentId;
     private String docTitle;
     private String docDescription;
     private String documentURI;
-    private Instant dateAddedToCase;
-    private boolean isIncludedInBundle;
-    private String creatorRole;
     private int sortIndex;
 
 
@@ -26,14 +21,6 @@ public class BundleDocumentDTO extends AbstractAuditingDTO implements Serializab
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-    public String getDocumentId() {
-        return documentId;
-    }
-
-    public void setDocumentId(String documentId) {
-        this.documentId = documentId;
     }
 
     public String getDocTitle() {
@@ -58,30 +45,6 @@ public class BundleDocumentDTO extends AbstractAuditingDTO implements Serializab
 
     public void setDocumentURI(String documentURI) {
         this.documentURI = documentURI;
-    }
-
-    public Instant getDateAddedToCase() {
-        return dateAddedToCase;
-    }
-
-    public void setDateAddedToCase(Instant dateAddedToCase) {
-        this.dateAddedToCase = dateAddedToCase;
-    }
-
-    public boolean isIncludedInBundle() {
-        return isIncludedInBundle;
-    }
-
-    public void setIncludedInBundle(boolean includedInBundle) {
-        isIncludedInBundle = includedInBundle;
-    }
-
-    public String getCreatorRole() {
-        return creatorRole;
-    }
-
-    public void setCreatorRole(String creatorRole) {
-        this.creatorRole = creatorRole;
     }
 
     public int getSortIndex() {

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/BundleFolderDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/BundleFolderDTO.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.em.stitching.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import javax.persistence.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImpl.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
 import uk.gov.hmcts.reform.em.stitching.service.DmStoreDownloader;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,8 +31,6 @@ public class DmStoreDownloaderImpl implements DmStoreDownloader {
     private final AuthTokenGenerator authTokenGenerator;
 
     private String dmStoreAppBaseUrl;
-
-    private final String dmStoreAppDocumentBinaryEndpointPattern = "/documents/%s/binary";
 
     public DmStoreDownloaderImpl(OkHttpClient okHttpClient,
                                  AuthTokenGenerator authTokenGenerator,
@@ -52,30 +52,29 @@ public class DmStoreDownloaderImpl implements DmStoreDownloader {
             Request request = new Request.Builder()
                     .addHeader("user-roles", "caseworker")
                     .addHeader("ServiceAuthorization", authTokenGenerator.generate())
-                    .url(dmStoreAppBaseUrl+String.format(dmStoreAppDocumentBinaryEndpointPattern, bundleDocument.getDocumentId()))
+                    .url(dmStoreAppBaseUrl+bundleDocument.getDocumentURI() + "/binary")
                     .build();
 
             Response response = okHttpClient.newCall(request).execute();
 
             if (response.isSuccessful()) {
-                Path tempPath = Paths.get(System.getProperty("java.io.tmpdir") + File.separator + bundleDocument.getDocumentId());
-
-                try {
-                    Files.copy(response.body().byteStream(), tempPath, StandardCopyOption.REPLACE_EXISTING);
-                }
-                catch (IOException e) {
-                    throw new DocumentTaskProcessingException("Could not copy the file to a temp location", e);
-                }
-
-                return tempPath.toFile();
-
-            }
-            else {
+                return copyResponseToFile(response);
+            } else {
                 throw new DocumentTaskProcessingException("Could not access the binary. HTTP response: " + response.code());
             }
-        }
-        catch (RuntimeException | IOException e) {
+        } catch (RuntimeException | IOException e) {
             throw new DocumentTaskProcessingException(String.format("Could not access the binary: %s", e.getMessage()), e);
+        }
+    }
+
+    private File copyResponseToFile(Response response) throws DocumentTaskProcessingException {
+        try {
+            File tempFile = File.createTempFile("dm-store", ".tmp");
+            Files.copy(response.body().byteStream(), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+            return tempFile;
+        } catch (IOException e) {
+            throw new DocumentTaskProcessingException("Could not copy the file to a temp location", e);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImpl.java
@@ -52,7 +52,7 @@ public class DmStoreDownloaderImpl implements DmStoreDownloader {
             Request request = new Request.Builder()
                     .addHeader("user-roles", "caseworker")
                     .addHeader("ServiceAuthorization", authTokenGenerator.generate())
-                    .url(dmStoreAppBaseUrl+bundleDocument.getDocumentURI() + "/binary")
+                    .url(dmStoreAppBaseUrl + bundleDocument.getDocumentURI() + "/binary")
                     .build();
 
             Response response = okHttpClient.newCall(request).execute();

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImpl.java
@@ -11,12 +11,8 @@ import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
 import uk.gov.hmcts.reform.em.stitching.service.DmStoreDownloader;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.stream.Stream;
 

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUploaderImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUploaderImpl.java
@@ -40,7 +40,7 @@ public class DmStoreUploaderImpl implements DmStoreUploader {
 
     @Override
     public void uploadFile(File file, DocumentTask documentTask) throws DocumentTaskProcessingException {
-        if (documentTask.getBundle().getStitchedDocId() != null) {
+        if (documentTask.getBundle().getStitchedDocumentURI() != null) {
             uploadNewDocumentVersion(file, documentTask);
         } else {
             uploadNewDocument(file, documentTask);
@@ -83,8 +83,7 @@ public class DmStoreUploaderImpl implements DmStoreUploader {
 
                 String documentId = split[split.length - 1];
 
-                documentTask.getBundle().setStitchedDocId(documentId);
-                documentTask.getBundle().setStitchedDocumentURI(dmStoreAppBaseUrl + dmStoreUploadEndpoint + "/" + documentId);
+                documentTask.getBundle().setStitchedDocumentURI(dmStoreUploadEndpoint + "/" + documentId);
             } else {
                 throw new DocumentTaskProcessingException("Couldn't upload the file. Response code: " + response.code(), null);
             }
@@ -108,7 +107,7 @@ public class DmStoreUploaderImpl implements DmStoreUploader {
                     .addHeader("user-id", getUserId(documentTask))
                     .addHeader("user-roles", "caseworker")
                     .addHeader("ServiceAuthorization", authTokenGenerator.generate())
-                    .url(dmStoreAppBaseUrl + dmStoreUploadEndpoint + "/" + documentTask.getBundle().getStitchedDocId())
+                    .url(dmStoreAppBaseUrl + documentTask.getBundle().getStitchedDocumentURI())
                     .method("POST", requestBody)
                     .build();
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,7 +21,7 @@ spring:
     enabled: ${ENABLE_LIQUIBASE:false}
     change-log: classpath:/db/db.changelog-master.xml
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/emstitch}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5431/emstitch}
     username: ${SPRING_DATASOURCE_USERNAME:emstitch}
     password: ${SPRING_DATASOURCE_PASSWORD:emstitch}
     tomcat:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,7 +21,7 @@ spring:
     enabled: ${ENABLE_LIQUIBASE:false}
     change-log: classpath:/db/db.changelog-master.xml
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5431/emstitch}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/emstitch}
     username: ${SPRING_DATASOURCE_USERNAME:emstitch}
     password: ${SPRING_DATASOURCE_PASSWORD:emstitch}
     tomcat:

--- a/src/main/resources/db/db.changelog-master.xml
+++ b/src/main/resources/db/db.changelog-master.xml
@@ -518,4 +518,37 @@
                 newDataType="varchar(5000)"
                 tableName="document_task"/>
     </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-13">
+        <dropColumn columnName="comments" tableName="bundle"/>
+    </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-14">
+        <dropColumn columnName="creator_role" tableName="bundle_document"/>
+    </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-15">
+        <dropColumn columnName="date_added_to_case" tableName="bundle_document"/>
+    </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-16">
+        <dropColumn columnName="date_locked" tableName="bundle"/>
+    </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-17">
+        <dropColumn columnName="document_id" tableName="bundle_document"/>
+    </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-18">
+        <dropColumn columnName="is_included_in_bundle" tableName="bundle_document"/>
+    </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-19">
+        <dropColumn columnName="is_locked" tableName="bundle"/>
+    </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-20">
+        <dropColumn columnName="locked_by" tableName="bundle"/>
+    </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-21">
+        <dropColumn columnName="purpose" tableName="bundle"/>
+    </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-22">
+        <dropColumn columnName="stitched_doc_id" tableName="bundle"/>
+    </changeSet>
+    <changeSet author="linus (generated)" id="1549871070285-23">
+        <dropColumn columnName="version" tableName="bundle"/>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/batch/DocumentTaskItemProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/batch/DocumentTaskItemProcessorTest.java
@@ -105,7 +105,7 @@ public class DocumentTaskItemProcessorTest {
 
         Mockito
             .doAnswer(any -> {
-                documentTask.getBundle().setStitchedDocId("derp");
+                documentTask.getBundle().setStitchedDocumentURI("/derp");
 
                 return documentTask;
             })
@@ -114,7 +114,7 @@ public class DocumentTaskItemProcessorTest {
         itemProcessor.process(documentTask);
 
         assertNull(documentTask.getFailureDescription());
-        assertNotEquals(null, documentTask.getBundle().getStitchedDocId());
+        assertNotEquals(null, documentTask.getBundle().getStitchedDocumentURI());
         assertEquals(TaskState.DONE, documentTask.getTaskState());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/BundleTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/BundleTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
 
 public class BundleTest {
-    private static final String DEFAULT_DOCUMENT_ID = "AAAAAAAAAA";
+    private static final String DEFAULT_DOCUMENT_ID = "/AAAAAAAAAA";
 
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -36,16 +36,15 @@ public class BundleTest {
         String result = mapper.writeValueAsString(bundle);
 
         assertThat(result, containsString("My bundle"));
-        assertThat(result, containsString("2019-01-09T14:00:00Z"));
+        assertThat(result, containsString(DEFAULT_DOCUMENT_ID));
     }
 
     public static Bundle getTestBundle() {
         BundleDocument bundleDocument = new BundleDocument();
-        bundleDocument.setDocumentId(DEFAULT_DOCUMENT_ID);
+        bundleDocument.setDocumentURI(DEFAULT_DOCUMENT_ID);
 
         Bundle bundle = new Bundle();
         bundle.setBundleTitle("My bundle");
-        bundle.setVersion(1);
         bundle.setDescription("Bundle description");
         bundle.setCreatedDate(Instant.parse("2019-01-09T14:00:00Z"));
         bundle.setCreatedBy("Billy Bob");
@@ -53,7 +52,6 @@ public class BundleTest {
         bundle.setFolders(new ArrayList<>());
 
         return bundle;
-
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResourceIntTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResourceIntTest.java
@@ -137,7 +137,7 @@ public class DocumentTaskResourceIntTest {
 
         // Create the DocumentTask
         DocumentTaskDTO documentTaskDTO = documentTaskMapper.toDto(documentTask);
-        documentTaskDTO.getBundle().setStitchedDocId(null);
+        documentTaskDTO.getBundle().setStitchedDocumentURI(null);
 
         restDocumentTaskMockMvc.perform(post("/api/document-tasks")
             .header("Authorization", documentTask.getJwt())

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImplTest.java
@@ -26,8 +26,8 @@ public class DmStoreDownloaderImplTest {
     public void downloadFile() throws Exception {
         BundleDocument mockBundleDocument1 = new BundleDocument();
         BundleDocument mockBundleDocument2 = new BundleDocument();
-        mockBundleDocument1.setDocumentId("AAAA");
-        mockBundleDocument2.setDocumentId("BBBB");
+        mockBundleDocument1.setDocumentURI("/AAAA");
+        mockBundleDocument2.setDocumentURI("/BBBB");
         Stream<File> results = dmStoreDownloader.downloadFiles(Stream.of(mockBundleDocument1, mockBundleDocument2));
 
         results.collect(Collectors.toList());


### PR DESCRIPTION
- Remove unused fields from entities
- Rely on the document URI rather than ID