### PR TITLE
Shedlock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,8 @@ dependencies {
     compile group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.13'
     compile 'com.squareup.okhttp3:okhttp:3.11.0'
     compile("org.springframework.boot:spring-boot-starter-batch")
+    compile group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version:'2.4.0'
+    compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version:'2.4.0'
     compile "com.fasterxml.jackson.datatype:jackson-datatype-json-org:${versions.jackson}"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-hppc:${versions.jackson}"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
@@ -177,7 +179,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '5.0.1'
     compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: '0.0.3'
     compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version:'0.0.4'
-    
+
     compile "org.hibernate.validator:hibernate-validator"
     compile "org.mapstruct:mapstruct-jdk8:${mapstruct_version}"
     compile "org.springframework.boot:spring-boot-starter-security"

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.em.stitching.domain;
 
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
+
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Comparator;
@@ -24,10 +27,12 @@ public class Bundle extends AbstractAuditingEntity implements SortableBundleItem
     private boolean hasCoversheets;
 
     @ElementCollection
+    @LazyCollection(LazyCollectionOption.FALSE)
     @OneToMany(cascade = CascadeType.ALL)
     private List<BundleFolder> folders = new ArrayList<>();
 
     @ElementCollection
+    @LazyCollection(LazyCollectionOption.FALSE)
     @OneToMany(cascade = CascadeType.ALL)
     private List<BundleDocument> documents = new ArrayList<>();
 

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/PersistentAuditEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/PersistentAuditEvent.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.em.stitching.domain;
 
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
+
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
@@ -34,6 +37,7 @@ public class PersistentAuditEvent implements Serializable {
     private String auditEventType;
 
     @ElementCollection
+    @LazyCollection(LazyCollectionOption.FALSE)
     @MapKeyColumn(name = "name")
     @Column(name = "value")
     @CollectionTable(name = "jhi_persistent_audit_evt_data", joinColumns = @JoinColumn(name = "event_id"))

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DocumentTaskServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DocumentTaskServiceImpl.java
@@ -95,10 +95,6 @@ public class DocumentTaskServiceImpl implements DocumentTaskService {
     @Override
     public DocumentTask process(DocumentTask documentTask) {
         try {
-            log.info(Long.toString(documentTask.getId()));
-            log.info(Boolean.toString(documentTask.getBundle().hasTableOfContents()));
-            log.info(Boolean.toString(documentTask.getBundle().hasCoversheets()));
-
             List<Pair<BundleDocument, File>> documents = dmStoreDownloader
                     .downloadFiles(documentTask.getBundle().getSortedItems())
                     .map(unchecked(documentConverter::convert))

--- a/src/main/resources/db/db.changelog-master.xml
+++ b/src/main/resources/db/db.changelog-master.xml
@@ -569,4 +569,9 @@
             </column>
         </addColumn>
     </changeSet>
+
+    <changeSet author="linus (manual)" id="shedlock-1">
+        <sqlFile path="shedlock.sql" relativeToChangelogFile="true"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/shedlock.sql
+++ b/src/main/resources/db/shedlock.sql
@@ -1,0 +1,7 @@
+CREATE TABLE shedlock(
+    name VARCHAR(64),
+    lock_until TIMESTAMP(3) NULL,
+    locked_at TIMESTAMP(3) NULL,
+    locked_by  VARCHAR(255),
+    PRIMARY KEY (name)
+)

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/batch/DocumentTaskItemProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/batch/DocumentTaskItemProcessorTest.java
@@ -8,7 +8,6 @@ import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.em.stitching.Application;
 import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
 import uk.gov.hmcts.reform.em.stitching.domain.BundleTest;
@@ -36,7 +35,6 @@ import static org.mockito.ArgumentMatchers.any;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-@Transactional
 public class DocumentTaskItemProcessorTest {
 
     private static final String PDF_FILENAME = "annotationTemplate.pdf";

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFCoversheetServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFCoversheetServiceTest.java
@@ -9,7 +9,6 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.util.Pair;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.em.stitching.Application;
 import uk.gov.hmcts.reform.em.stitching.domain.Bundle;
 import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
@@ -21,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-@Transactional
 public class PDFCoversheetServiceTest {
 
     private final PDFCoversheetService documentFormatter = new PDFCoversheetService();

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/repository/CustomAuditEventRepositoryIntTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/repository/CustomAuditEventRepositoryIntTest.java
@@ -10,7 +10,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.em.stitching.Application;
 import uk.gov.hmcts.reform.em.stitching.config.Constants;
 import uk.gov.hmcts.reform.em.stitching.config.audit.AuditEventConverter;
@@ -32,7 +31,6 @@ import static uk.gov.hmcts.reform.em.stitching.repository.CustomAuditEventReposi
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-@Transactional
 public class CustomAuditEventRepositoryIntTest {
 
     @Autowired

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/repository/CustomAuditEventRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/repository/CustomAuditEventRepositoryTest.java
@@ -7,18 +7,14 @@ import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.em.stitching.Application;
 import uk.gov.hmcts.reform.em.stitching.config.audit.AuditEventConverter;
 
 import java.time.Instant;
 import java.util.List;
 
-import static org.junit.Assert.*;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-@Transactional
 public class CustomAuditEventRepositoryTest {
 
     @MockBean

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResourceIntTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResourceIntTest.java
@@ -16,7 +16,6 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.auth.checker.core.SubjectResolver;
 import uk.gov.hmcts.reform.auth.checker.core.user.User;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
@@ -113,7 +112,6 @@ public class DocumentTaskResourceIntTest {
     }
 
     @Test
-    @Transactional
     public void createDocumentTask() throws Exception {
         BDDMockito.given(authTokenGenerator.generate()).willReturn("s2s");
         BDDMockito.given(userResolver.getTokenDetails(documentTask.getJwt())).willReturn(new User("id", null));
@@ -139,7 +137,6 @@ public class DocumentTaskResourceIntTest {
     }
 
     @Test
-    @Transactional
     public void createDocumentTaskWithExistingId() throws Exception {
         int databaseSizeBeforeCreate = documentTaskRepository.findAll().size();
 
@@ -159,7 +156,6 @@ public class DocumentTaskResourceIntTest {
     }
     
     @Test
-    @Transactional
     public void getDocumentTask() throws Exception {
         // Initialize the database
         documentTaskRepository.saveAndFlush(documentTask);
@@ -174,7 +170,6 @@ public class DocumentTaskResourceIntTest {
     }
 
     @Test
-    @Transactional
     public void getNonExistingDocumentTask() throws Exception {
         // Get the documentTask
         restDocumentTaskMockMvc.perform(get("/api/document-tasks/{id}", Long.MAX_VALUE))
@@ -182,7 +177,6 @@ public class DocumentTaskResourceIntTest {
     }
 
     @Test
-    @Transactional
     public void equalsVerifier() throws Exception {
         TestUtil.equalsVerifier(DocumentTask.class);
         DocumentTask documentTask1 = new DocumentTask();
@@ -197,7 +191,6 @@ public class DocumentTaskResourceIntTest {
     }
 
     @Test
-    @Transactional
     public void dtoEqualsVerifier() throws Exception {
         TestUtil.equalsVerifier(DocumentTaskDTO.class);
         DocumentTaskDTO documentTaskDto1 = new DocumentTaskDTO();

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreDownloaderImplTest.java
@@ -9,7 +9,6 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.util.Pair;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.em.stitching.Application;
 import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
 import uk.gov.hmcts.reform.em.stitching.service.DmStoreDownloader;
@@ -22,7 +21,6 @@ import java.util.stream.Stream;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-@Transactional
 public class DmStoreDownloaderImplTest {
 
     private static final String PDF_FILENAME = "annotationTemplate.pdf";

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUploaderImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUploaderImplTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.auth.checker.core.user.User;
 import uk.gov.hmcts.reform.em.stitching.Application;
 import uk.gov.hmcts.reform.em.stitching.domain.Bundle;
@@ -20,7 +19,6 @@ import java.util.HashSet;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-@Transactional
 public class DmStoreUploaderImplTest {
 
     DmStoreUploader dmStoreUploader;

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DocumentConversionServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DocumentConversionServiceImplTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.util.Pair;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.em.stitching.Application;
 import uk.gov.hmcts.reform.em.stitching.conversion.PDFConverter;
 import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
@@ -23,7 +22,6 @@ import java.util.Collections;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
-@Transactional
 public class DocumentConversionServiceImplTest {
 
     @MockBean


### PR DESCRIPTION
Add shedlock to prevent spring batch from executing multiple jobs at the same time.

Also fixed a couple of hibernate session issues after local testing with multiple instances.