### PR TITLE
automatically add .pdf to all filenames

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
@@ -93,7 +93,7 @@ public class Bundle extends AbstractAuditingEntity implements SortableBundleItem
     }
 
     public String getFileName() {
-        return fileName == null || fileName.isEmpty() ? bundleTitle + ".pdf" : fileName;
+        return fileName == null || fileName.isEmpty() ? bundleTitle : fileName;
     }
 
     public void setFileName(String fileName) {

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUploaderImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUploaderImpl.java
@@ -54,7 +54,7 @@ public class DmStoreUploaderImpl implements DmStoreUploader {
                     .addFormDataPart("classification", "PUBLIC")
                     .addFormDataPart(
                         "files",
-                        documentTask.getBundle().getFileName(),
+                        documentTask.getBundle().getFileName() + ".pdf",
                         RequestBody.create(MediaType.get("application/pdf"), file))
                     .build();
 
@@ -66,15 +66,7 @@ public class DmStoreUploaderImpl implements DmStoreUploader {
                     .method("POST", requestBody)
                     .build();
 
-            System.out.println("JJJ - in DmStoreUploaderImpl. Request to DmStore is ");
-            System.out.println(request.toString());
-            System.out.println("JJJ - Request body is ");
-            System.out.println(request.body());
             Response response = okHttpClient.newCall(request).execute();
-            System.out.println("JJJ - Response from DmStore is ");
-            System.out.println(response.toString());
-            System.out.println("JJJ - Response body is ");
-            System.out.println(response.body());
 
             if (response.isSuccessful()) {
 

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUploaderImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUploaderImpl.java
@@ -54,7 +54,7 @@ public class DmStoreUploaderImpl implements DmStoreUploader {
                     .addFormDataPart("classification", "PUBLIC")
                     .addFormDataPart(
                         "files",
-                        documentTask.getBundle().getFileName() + ".pdf",
+                        formatFileName(documentTask.getBundle().getFileName()),
                         RequestBody.create(MediaType.get("application/pdf"), file))
                     .build();
 
@@ -120,6 +120,10 @@ public class DmStoreUploaderImpl implements DmStoreUploader {
     private String getUserId(DocumentTask documentTask) {
         User user = userResolver.getTokenDetails(documentTask.getJwt());
         return user.getPrincipal();
+    }
+
+    private String formatFileName(String f) {
+        return f.endsWith(".pdf") ? f : f + ".pdf";
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUriFormatter.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUriFormatter.java
@@ -16,7 +16,7 @@ public class DmStoreUriFormatter {
         if (s.contains("/documents/")) {
             s = s.substring(s.indexOf("/documents/"));
             s = s.endsWith("/binary") ? s : s + "/binary";
-            s = this.dmStoreAppBaseUrl.concat(s);
+            s = this.dmStoreAppBaseUrl + s;
         }
         return s;
     }

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/BundleTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/BundleTest.java
@@ -43,7 +43,7 @@ public class BundleTest {
         Bundle bundle = BundleTest.getTestBundle();
         bundle.setFileName(null);
 
-        assertEquals(bundle.getFileName(), bundle.getBundleTitle() + ".pdf");
+        assertEquals(bundle.getFileName(), bundle.getBundleTitle());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUriFormatterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/service/impl/DmStoreUriFormatterTest.java
@@ -18,18 +18,18 @@ public class DmStoreUriFormatterTest {
     @Test
     public void doesAppendBinary() {
         String result = dmStoreUriFormatter.formatDmStoreUri(mockCorruptedDocumentUri);
-        Assert.assertEquals(mockBaseUri.concat(mockDocumentDetails).concat(binary), result);
+        Assert.assertEquals((mockBaseUri + mockDocumentDetails + binary), result);
     }
 
     @Test
     public void doesNotAppendBinaryWhenAlreadyPresent() {
-        String result = dmStoreUriFormatter.formatDmStoreUri(mockCorruptedDocumentUri.concat(binary));
-        Assert.assertEquals(mockBaseUri.concat(mockDocumentDetails).concat(binary), result);
+        String result = dmStoreUriFormatter.formatDmStoreUri(mockCorruptedDocumentUri + binary);
+        Assert.assertEquals((mockBaseUri + mockDocumentDetails + binary), result);
     }
 
     @Test
     public void doesNotAppendBinaryWhenNoDocumentsInString() {
-        String mockUri = mockBaseUri.concat("/12345");
+        String mockUri = (mockBaseUri + "/12345");
         Assert.assertEquals(mockUri, dmStoreUriFormatter.formatDmStoreUri(mockUri));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
EM-1543


### Change description ###
422 error from DM store occurs when a doc is uploaded, if the pdf's name does not include its mime type. To avoid this from happening, we're sticking ".pdf" to the end of every pdf. 

Linus and Jeroen had agreed on this approach, but had only implemented it in cases where no filename was set, and bundle title was used instead. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
