### PR TITLE
Update unit tests for pdf merger

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMergerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMergerTest.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.reform.em.stitching.pdf;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
-import org.junit.Before;
+import org.junit.Assert;
 import org.junit.Test;
 import uk.gov.hmcts.reform.em.stitching.domain.Bundle;
 import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
@@ -13,8 +13,7 @@ import java.io.IOException;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
-import static uk.gov.hmcts.reform.em.stitching.pdf.PDFMergerTestUtil.createFlatTestBundle;
-import static uk.gov.hmcts.reform.em.stitching.pdf.PDFMergerTestUtil.countSubstrings;
+import static uk.gov.hmcts.reform.em.stitching.pdf.PDFMergerTestUtil.*;
 
 public class PDFMergerTest {
     private static final File FILE_1 = new File(
@@ -28,8 +27,7 @@ public class PDFMergerTest {
     private Bundle bundle;
     private HashMap<BundleDocument, File> documents;
 
-    @Before
-    public void setup() {
+    private void flatSetup() {
         bundle = createFlatTestBundle();
         documents = new HashMap<>();
 
@@ -39,6 +37,7 @@ public class PDFMergerTest {
 
     @Test
     public void mergeWithTableOfContents() throws IOException {
+        flatSetup();
         PDFMerger merger = new PDFMerger();
         bundle.setHasTableOfContents(true);
         File merged = merger.merge(bundle, documents);
@@ -57,46 +56,8 @@ public class PDFMergerTest {
     }
 
     @Test
-    public void mergeWithFolderCoversheets() throws IOException {
-        Bundle bundleWithFolders = new Bundle();
-
-        BundleDocument bundleDocument = new BundleDocument();
-        bundleDocument.setDocTitle("Bundle Doc 1");
-        BundleFolder folder1 = new BundleFolder();
-        folder1.getDocuments().add(bundleDocument);
-        bundleWithFolders.getFolders().add(folder1);
-
-        BundleDocument bundleDocument2 = new BundleDocument();
-        bundleDocument2.setDocTitle("Bundle Doc 2");
-        BundleFolder folder2 = new BundleFolder();
-        folder2.getDocuments().add(bundleDocument2);
-        bundleWithFolders.getFolders().add(folder2);
-
-        bundleWithFolders.setHasTableOfContents(false);
-        bundleWithFolders.setHasFolderCoversheets(true);
-
-        HashMap<BundleDocument, File> documents = new HashMap<>();
-        documents.put(bundleDocument, FILE_1);
-        documents.put(bundleDocument2, FILE_2);
-
-        PDFMerger merger = new PDFMerger();
-        File merged = merger.merge(bundleWithFolders, documents);
-        PDDocument mergedDocument = PDDocument.load(merged);
-
-        PDDocument doc1 = PDDocument.load(FILE_1);
-        PDDocument doc2 = PDDocument.load(FILE_2);
-
-        final int numberOfPagesInTableOfContents = 2;
-        final int expectedPages = doc1.getNumberOfPages() + doc2.getNumberOfPages() + numberOfPagesInTableOfContents;
-
-        doc1.close();
-        doc2.close();
-
-        assertEquals(expectedPages, mergedDocument.getNumberOfPages());
-    }
-
-    @Test
     public void mergeWithoutTableOfContents() throws IOException {
+        flatSetup();
         PDFMerger merger = new PDFMerger();
         bundle.setHasTableOfContents(false);
 
@@ -116,6 +77,7 @@ public class PDFMergerTest {
 
     @Test
     public void tableOfContentsBundleTitleFrequencyTest() throws IOException {
+        flatSetup();
         PDFMerger merger = new PDFMerger();
         PDFTextStripper pdfStripper = new PDFTextStripper();
         final int bundleTextInTableOfContentsFrequency = 1;
@@ -136,6 +98,7 @@ public class PDFMergerTest {
 
     @Test
     public void noTableOfContentsBundleTitleFrequencyTest() throws IOException {
+        flatSetup();
         PDFMerger merger = new PDFMerger();
         PDFTextStripper pdfStripper = new PDFTextStripper();
         bundle.setHasTableOfContents(false);
@@ -150,27 +113,164 @@ public class PDFMergerTest {
         int secondDocBundleTitleFrequency = countSubstrings(secondFileDocumentText, bundle.getBundleTitle());
         int expectedBundleTitleFrequency = firstDocBundleTitleFrequency + secondDocBundleTitleFrequency;
         assertEquals(stitchedDocBundleTitleFrequency, expectedBundleTitleFrequency);
+    }
+
+
+    //  Folder Coversheets stuff //
+
+    @Test
+    public void addFolderCoversheetsTest() throws IOException {
+        bundle = createFolderedTestBundle();
+        BundleFolder bundleFolder = bundle.getFolders().get(0);
+        BundleDocument bundleDocument = bundleFolder.getDocuments().get(0);
+        BundleDocument bundleDocument2 = bundle.getDocuments().get(0);
+
+        HashMap<BundleDocument, File> documents = new HashMap<>();
+        documents.put(bundleDocument, FILE_1);
+        documents.put(bundleDocument2, FILE_2);
+
+        PDFMerger merger = new PDFMerger();
+        File merged = merger.merge(bundle, documents);
+        PDDocument mergedDocument = PDDocument.load(merged);
+
+        PDDocument doc1 = PDDocument.load(FILE_1);
+        PDDocument doc2 = PDDocument.load(FILE_2);
+
+        final int numberOfTOCPages = 1;
+        final int numberOfDocCoversheets = 0;
+        final int numberOfFolderCoversheets = 1;
+        final int numberOfExtraPages = numberOfTOCPages + numberOfDocCoversheets + numberOfFolderCoversheets;
+        final int expectedPages = doc1.getNumberOfPages() + doc2.getNumberOfPages() + numberOfExtraPages;
+        final int actualPages = mergedDocument.getNumberOfPages();
+
+        assertEquals(expectedPages, actualPages);
+
+        PDFTextStripper pdfStripper = new PDFTextStripper();
+        String stitchedDocumentText = pdfStripper.getText(mergedDocument);
+        int noOfBundleFolderDescriptions = countSubstrings(stitchedDocumentText, bundleFolder.getDescription());
+
+        assertEquals(1, noOfBundleFolderDescriptions);
+
+        doc1.close();
+        doc2.close();
+        mergedDocument.close();
     }
 
     @Test
-    public void addFolderCoversheets() throws IOException {
+    public void folderCoversheetsToggleOffTest() throws IOException {
+        bundle = createFolderedTestBundle();
+        bundle.setHasFolderCoversheets(false);
+
+        BundleDocument bundleDocument = bundle.getFolders().get(0).getDocuments().get(0);
+        BundleDocument bundleDocument2 = bundle.getDocuments().get(0);
+
+        HashMap<BundleDocument, File> documents = new HashMap<>();
+        documents.put(bundleDocument, FILE_1);
+        documents.put(bundleDocument2, FILE_2);
+
         PDFMerger merger = new PDFMerger();
-        PDFTextStripper pdfStripper = new PDFTextStripper();
-        bundle.setHasTableOfContents(false);
-        File stitched = merger.merge(bundle, documents);
+        File merged = merger.merge(bundle, documents);
+        PDDocument mergedDocument = PDDocument.load(merged);
 
-        String stitchedDocumentText = pdfStripper.getText(PDDocument.load(stitched));
-        String firstFileDocumentText = pdfStripper.getText(PDDocument.load(FILE_1));
-        String secondFileDocumentText = pdfStripper.getText(PDDocument.load(FILE_2));
+        PDDocument doc1 = PDDocument.load(FILE_1);
+        PDDocument doc2 = PDDocument.load(FILE_2);
 
-        int stitchedDocBundleTitleFrequency = countSubstrings(stitchedDocumentText, bundle.getBundleTitle());
-        int firstDocBundleTitleFrequency = countSubstrings(firstFileDocumentText, bundle.getBundleTitle());
-        int secondDocBundleTitleFrequency = countSubstrings(secondFileDocumentText, bundle.getBundleTitle());
-        int expectedBundleTitleFrequency = firstDocBundleTitleFrequency + secondDocBundleTitleFrequency;
-        assertEquals(stitchedDocBundleTitleFrequency, expectedBundleTitleFrequency);
+        final int numberOfTOCPages = 1;
+        final int numberOfDocCoversheets = 0;
+        final int numberOfFolderCoversheets = 0;
+        final int numberOfExtraPages = numberOfTOCPages + numberOfDocCoversheets + numberOfFolderCoversheets;
+        final int expectedPages = doc1.getNumberOfPages() + doc2.getNumberOfPages() + numberOfExtraPages;
+        final int actualPages = mergedDocument.getNumberOfPages();
+
+        doc1.close();
+        doc2.close();
+        mergedDocument.close();
+
+        Assert.assertEquals(expectedPages, actualPages);
     }
 
-    // Test things like folder coversheets, folder docs merging in order etc
+    @Test
+    public void mergeWithMultipleFolderCoversheets() throws IOException {
+        Bundle bundle = createMultiFolderedTestBundle();
+        bundle.setHasTableOfContents(false);
+        bundle.setHasFolderCoversheets(true);
+        bundle.setHasCoversheets(false);
+
+        BundleDocument bundleDocument1 = bundle.getFolders().get(0).getDocuments().get(0);
+        BundleDocument bundleDocument2 = bundle.getFolders().get(1).getDocuments().get(0);
+
+        HashMap<BundleDocument, File> documents = new HashMap<>();
+        documents.put(bundleDocument1, FILE_1);
+        documents.put(bundleDocument2, FILE_2);
+
+        PDFMerger merger = new PDFMerger();
+        File merged = merger.merge(bundle, documents);
+        PDDocument mergedDocument = PDDocument.load(merged);
+
+        PDDocument doc1 = PDDocument.load(FILE_1);
+        PDDocument doc2 = PDDocument.load(FILE_2);
+
+        final int numberOfTOCPages = 0;
+        final int numberOfDocCoversheets = 0;
+        final int numberOfFolderCoversheets = 2;
+        final int numberOfExtraPages = numberOfTOCPages + numberOfDocCoversheets + numberOfFolderCoversheets;
+        final int expectedPages = doc1.getNumberOfPages() + doc2.getNumberOfPages() + numberOfExtraPages;
+        assertEquals(expectedPages, mergedDocument.getNumberOfPages());
+
+        PDFTextStripper pdfStripper = new PDFTextStripper();
+        String stitchedDocumentText = pdfStripper.getText(mergedDocument);
+        String folder1Description = bundle.getFolders().get(0).getDescription();
+        String folder2Description = bundle.getFolders().get(1).getDescription();
+
+        int indexOfFolder1Description = stitchedDocumentText.indexOf(folder1Description);
+        int indexOfFolder2Description = stitchedDocumentText.indexOf(folder2Description);
+        int stitchedDocFolder1DescriptionFrequency = countSubstrings(stitchedDocumentText, folder1Description);
+        int stitchedDocFolder2DescriptionFrequency = countSubstrings(stitchedDocumentText, folder2Description);
+
+        assertEquals(1, stitchedDocFolder1DescriptionFrequency);
+        assertEquals(1, stitchedDocFolder2DescriptionFrequency);
+        Assert.assertTrue(indexOfFolder1Description < indexOfFolder2Description);
+
+        doc1.close();
+        doc2.close();
+        mergedDocument.close();
+    }
+
+
+    @Test
+    public void ignoresEmptyFoldersTest() throws IOException {
+        bundle = createFolderedTestBundle();
+        BundleFolder bundleFolder = bundle.getFolders().get(0);
+        bundleFolder.getDocuments().clear();
+        BundleDocument bundleDocument2 = bundle.getDocuments().get(0);
+
+        HashMap<BundleDocument, File> documents = new HashMap<>();
+        documents.put(bundleDocument2, FILE_2);
+
+        PDFMerger merger = new PDFMerger();
+        File merged = merger.merge(bundle, documents);
+        PDDocument mergedDocument = PDDocument.load(merged);
+
+        PDDocument doc2 = PDDocument.load(FILE_2);
+
+        final int numberOfTOCPages = 1;
+        final int numberOfDocCoversheets = 0;
+        final int numberOfFolderCoversheets = 0;
+        final int numberOfExtraPages = numberOfTOCPages + numberOfDocCoversheets + numberOfFolderCoversheets;
+        final int expectedPages = doc2.getNumberOfPages() + numberOfExtraPages;
+        final int actualPages = mergedDocument.getNumberOfPages();
+
+        assertEquals(expectedPages, actualPages);
+
+        PDFTextStripper pdfStripper = new PDFTextStripper();
+        String stitchedDocumentText = pdfStripper.getText(mergedDocument);
+        int noOfBundleFolderDescriptions = countSubstrings(stitchedDocumentText, bundleFolder.getDescription());
+
+        assertEquals(0, noOfBundleFolderDescriptions);
+
+        doc2.close();
+        mergedDocument.close();
+    }
 
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMergerTestUtil.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMergerTestUtil.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.em.stitching.pdf;
+
+import uk.gov.hmcts.reform.em.stitching.domain.Bundle;
+import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
+
+class PDFMergerTestUtil {
+
+    private PDFMergerTestUtil() { }
+
+    // Utils //
+    static Bundle createFlatTestBundle() {
+        Bundle bundle = new Bundle();
+        bundle.setBundleTitle("Title of the bundle");
+        bundle.setDescription("This is the description, it should really be wrapped but it is not currently. The table limit is 255 characters anyway.");
+        bundle.setHasTableOfContents(true);
+        bundle.setHasCoversheets(true);
+        bundle.setHasFolderCoversheets(false);
+
+        BundleDocument bundleDocument = new BundleDocument();
+        bundleDocument.setDocumentURI("AAAAAAA");
+        bundleDocument.setDocTitle("Bundle Doc 1");
+        bundleDocument.setId(1L);
+        bundle.getDocuments().add(bundleDocument);
+
+        BundleDocument bundleDocument2 = new BundleDocument();
+        bundleDocument2.setDocumentURI("BBBBBBB");
+        bundleDocument2.setDocTitle("Bundle Doc 2");
+        bundleDocument2.setId(1L);
+        bundle.getDocuments().add(bundleDocument2);
+
+        return bundle;
+    }
+
+    static int countSubstrings(String text, String find) {
+        int index = 0;
+        int count = 0;
+        int length = find.length();
+        while ((index = text.indexOf(find, index)) != -1) {
+            index += length;
+            count++;
+        }
+        return count;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMergerTestUtil.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMergerTestUtil.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.em.stitching.pdf;
 
 import uk.gov.hmcts.reform.em.stitching.domain.Bundle;
 import uk.gov.hmcts.reform.em.stitching.domain.BundleDocument;
+import uk.gov.hmcts.reform.em.stitching.domain.BundleFolder;
 
 class PDFMergerTestUtil {
 
@@ -13,7 +14,7 @@ class PDFMergerTestUtil {
         bundle.setBundleTitle("Title of the bundle");
         bundle.setDescription("This is the description, it should really be wrapped but it is not currently. The table limit is 255 characters anyway.");
         bundle.setHasTableOfContents(true);
-        bundle.setHasCoversheets(true);
+        bundle.setHasCoversheets(false);
         bundle.setHasFolderCoversheets(false);
 
         BundleDocument bundleDocument = new BundleDocument();
@@ -30,6 +31,76 @@ class PDFMergerTestUtil {
 
         return bundle;
     }
+
+    static Bundle createFolderedTestBundle() {
+        Bundle bundle = new Bundle();
+        bundle.setBundleTitle("Title of the bundle");
+        bundle.setDescription("This is the description, it should really be wrapped but it is not currently. The table limit is 255 characters anyway.");
+        bundle.setHasTableOfContents(true);
+        bundle.setHasCoversheets(false);
+        bundle.setHasFolderCoversheets(true);
+
+        BundleDocument bundleDocument = new BundleDocument();
+        bundleDocument.setDocumentURI("AAAAAAA");
+        bundleDocument.setDocTitle("Bundle Doc 1");
+        bundleDocument.setId(1L);
+        bundleDocument.setSortIndex(1);
+
+        BundleDocument bundleDocument2 = new BundleDocument();
+        bundleDocument2.setDocumentURI("BBBBBBB");
+        bundleDocument2.setDocTitle("Bundle Doc 2");
+        bundleDocument2.setId(2L);
+        bundleDocument2.setSortIndex(2);
+
+        BundleFolder folder = new BundleFolder();
+        folder.setFolderName("Folder 1");
+        folder.setDescription("This is folder 1");
+        folder.setSortIndex(1);
+        folder.getDocuments().add(bundleDocument);
+
+        bundle.getFolders().add(folder);
+        bundle.getDocuments().add(bundleDocument2);
+
+        return bundle;
+    }
+
+    static Bundle createMultiFolderedTestBundle() {
+        Bundle bundle = new Bundle();
+        bundle.setBundleTitle("Title of the bundle");
+        bundle.setDescription("This is the description, it should really be wrapped but it is not currently. The table limit is 255 characters anyway.");
+        bundle.setHasTableOfContents(true);
+        bundle.setHasCoversheets(false);
+        bundle.setHasFolderCoversheets(true);
+
+        BundleDocument bundleDocument1 = new BundleDocument();
+        bundleDocument1.setDocumentURI("AAAAAAA");
+        bundleDocument1.setDocTitle("Bundle Doc 1");
+        bundleDocument1.setId(1L);
+        bundleDocument1.setSortIndex(1);
+
+        BundleFolder folder1 = new BundleFolder();
+        folder1.setFolderName("Folder 1");
+        folder1.setDescription("The first folder description - this is for folder 1");
+        folder1.setSortIndex(1);
+        folder1.getDocuments().add(bundleDocument1);
+
+        BundleDocument bundleDocument2 = new BundleDocument();
+        bundleDocument2.setDocumentURI("BBBBBBB");
+        bundleDocument2.setDocTitle("A separate description - this one is of folder 2");
+        bundleDocument2.setId(2L);
+        bundleDocument2.setSortIndex(2);
+
+        BundleFolder folder2 = new BundleFolder();
+        folder2.setFolderName("Folder 2");
+        folder2.setDescription("This is folder 2");
+        folder2.setSortIndex(2);
+        folder2.getDocuments().add(bundleDocument2);
+
+        bundle.getFolders().add(folder1);
+        bundle.getFolders().add(folder2);
+        return bundle;
+    }
+
 
     static int countSubstrings(String text, String find) {
         int index = 0;


### PR DESCRIPTION
I wrote some things
### JIRA link (if applicable) ###
1484
### Change description ###
coversheet unit tests in pdf merger. Fairly high level cause pdfmerger methods are private

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
