### PR TITLE
EM-2308 - callback validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ dependencies {
     testCompile 'io.rest-assured:json-path:4.1.2'
     testCompile 'io.rest-assured:xml-path:4.1.2'
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+    testCompile "com.github.tomakehurst:wiremock-jre8:2.25.1"
 
     testCompile "org.junit.jupiter:junit-jupiter-api:5.5.2"
     testRuntime "org.junit.jupiter:junit-jupiter-engine:5.5.2"

--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,6 @@ dependencies {
     testCompile 'io.rest-assured:json-path:4.1.2'
     testCompile 'io.rest-assured:xml-path:4.1.2'
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
-    testCompile "com.github.tomakehurst:wiremock-jre8:2.25.1"
 
     testCompile "org.junit.jupiter:junit-jupiter-api:5.5.2"
     testRuntime "org.junit.jupiter:junit-jupiter-engine:5.5.2"

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
@@ -186,7 +186,7 @@ public class DocumentTaskScenarios {
         Assert.assertEquals(400, createTaskResponse.getStatusCode());
         Assert.assertEquals("callback.callbackUrl",
                 createTaskResponse.getBody().jsonPath().getString("fieldErrors[0].field"));
-        Assert.assertEquals("Connection to the callback URL could not be verified. ",
+        Assert.assertEquals("Connection to the callback URL could not be verified.",
                 createTaskResponse.getBody().jsonPath().getString("fieldErrors[0].message"));
 
     }

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
@@ -166,7 +166,7 @@ public class DocumentTaskScenarios {
     }
 
     @Test
-    public void testPostBundleStitchWithCallbackUrlNotAccessible() throws IOException, InterruptedException {
+    public void testPostBundleStitchWithCallbackUrlNotAccessible() throws IOException {
         BundleDTO bundle = testUtil.getTestBundle();
         DocumentTaskDTO documentTask = new DocumentTaskDTO();
         documentTask.setBundle(bundle);
@@ -186,7 +186,8 @@ public class DocumentTaskScenarios {
         Assert.assertEquals(400, createTaskResponse.getStatusCode());
         Assert.assertEquals("callback.callbackUrl",
                 createTaskResponse.getBody().jsonPath().getString("fieldErrors[0].field"));
-
+        Assert.assertEquals("Connection to the callback URL could not be verified. ",
+                createTaskResponse.getBody().jsonPath().getString("fieldErrors[0].message"));
 
     }
 }

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.em.stitching.functional;
 
+import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.response.Response;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -26,7 +27,7 @@ public class DocumentTaskScenarios {
     private TestUtil testUtil = new TestUtil();
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8089);
+    public WireMockRule wireMockRule = new WireMockRule(Options.DYNAMIC_PORT);
 
     @Test
     public void testPostBundleStitch() throws IOException, InterruptedException {
@@ -149,6 +150,8 @@ public class DocumentTaskScenarios {
 
     @Test
     public void testPostBundleStitchWithCallback() throws IOException, InterruptedException {
+
+
         stubFor(post(urlEqualTo("/my/callback/resource"))
                 .willReturn(aResponse()
                         .withStatus(200)));
@@ -158,7 +161,7 @@ public class DocumentTaskScenarios {
         documentTask.setBundle(bundle);
 
         CallbackDto callback = new CallbackDto();
-        callback.setCallbackUrl("http://localhost:8089/my/callback/resource");
+        callback.setCallbackUrl(wireMockRule.baseUrl() + "/my/callback/resource");
 
         documentTask.setCallback(callback);
 
@@ -168,7 +171,7 @@ public class DocumentTaskScenarios {
                 .body(TestUtil.convertObjectToJsonBytes(documentTask))
                 .request("POST", Env.getTestUrl() + "/api/document-tasks");
         Assert.assertEquals(201, createTaskResponse.getStatusCode());
-        Assert.assertEquals("http://localhost:8089/my/callback/resource",
+        Assert.assertEquals(wireMockRule.baseUrl() + "/my/callback/resource",
                 createTaskResponse.getBody().jsonPath().getString("callback.callbackUrl"));
 
         String taskUrl = "/api/document-tasks/" + createTaskResponse.getBody().jsonPath().getString("id");

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/DocumentTaskScenarios.java
@@ -1,12 +1,9 @@
 package uk.gov.hmcts.reform.em.stitching.functional;
 
-import com.github.tomakehurst.wiremock.core.Options;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.response.Response;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.http.MediaType;
 import uk.gov.hmcts.reform.em.stitching.domain.enumeration.TaskState;
@@ -19,15 +16,9 @@ import uk.gov.hmcts.reform.em.stitching.testutil.TestUtil;
 import java.io.File;
 import java.io.IOException;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-
 public class DocumentTaskScenarios {
 
     private TestUtil testUtil = new TestUtil();
-
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(Options.DYNAMIC_PORT);
 
     @Test
     public void testPostBundleStitch() throws IOException, InterruptedException {
@@ -151,17 +142,12 @@ public class DocumentTaskScenarios {
     @Test
     public void testPostBundleStitchWithCallback() throws IOException, InterruptedException {
 
-
-        stubFor(post(urlEqualTo("/my/callback/resource"))
-                .willReturn(aResponse()
-                        .withStatus(200)));
-
         BundleDTO bundle = testUtil.getTestBundle();
         DocumentTaskDTO documentTask = new DocumentTaskDTO();
         documentTask.setBundle(bundle);
 
         CallbackDto callback = new CallbackDto();
-        callback.setCallbackUrl(wireMockRule.baseUrl() + "/my/callback/resource");
+        callback.setCallbackUrl("https://postman-echo.com/post");
 
         documentTask.setCallback(callback);
 
@@ -171,7 +157,7 @@ public class DocumentTaskScenarios {
                 .body(TestUtil.convertObjectToJsonBytes(documentTask))
                 .request("POST", Env.getTestUrl() + "/api/document-tasks");
         Assert.assertEquals(201, createTaskResponse.getStatusCode());
-        Assert.assertEquals(wireMockRule.baseUrl() + "/my/callback/resource",
+        Assert.assertEquals("https://postman-echo.com/post",
                 createTaskResponse.getBody().jsonPath().getString("callback.callbackUrl"));
 
         String taskUrl = "/api/document-tasks/" + createTaskResponse.getBody().jsonPath().getString("id");

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/config/MessageSourceConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/config/MessageSourceConfiguration.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.em.stitching.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.SessionLocaleResolver;
+
+import java.util.Locale;
+
+@Configuration
+public class MessageSourceConfiguration {
+
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource
+                = new ReloadableResourceBundleMessageSource();
+
+        messageSource.setBasename("classpath:messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        return messageSource;
+    }
+
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        SessionLocaleResolver slr = new SessionLocaleResolver();
+        slr.setDefaultLocale(Locale.UK);
+        return slr;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpoint.java
@@ -6,7 +6,7 @@ import java.lang.annotation.*;
 
 @Documented
 @Constraint(validatedBy = CallableEndpointValidator.class)
-@Target( { ElementType.METHOD, ElementType.FIELD })
+@Target({ ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CallableEndpoint {
     String message() default "Endpoint could not be called.";

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpoint.java
@@ -9,7 +9,7 @@ import java.lang.annotation.*;
 @Target({ ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CallableEndpoint {
-    String message() default "Endpoint could not be called.";
+    String message() default "{CallableEndpoint.documentTaskDTO.callback.callbackUrl}";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpoint.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.em.stitching.domain.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CallableEndpointValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CallableEndpoint {
+    String message() default "Endpoint could not be called.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpointValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpointValidator.java
@@ -15,6 +15,8 @@ public class CallableEndpointValidator implements ConstraintValidator<CallableEn
     @Override
     public boolean isValid(String url, ConstraintValidatorContext context) {
 
+        boolean valid;
+
         try {
             URL siteURL = new URL(url);
             HttpURLConnection connection = (HttpURLConnection) siteURL.openConnection();
@@ -23,11 +25,12 @@ public class CallableEndpointValidator implements ConstraintValidator<CallableEn
             connection.connect();
             int responseCode = connection.getResponseCode();
             connection.disconnect();
-            return responseCode < 500;
+            valid = responseCode < 500;
         } catch (Exception e) {
             log.error(String.format("Callback %s could not be called", url), e);
-            return false;
+            valid = false;
         }
+        return valid;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpointValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpointValidator.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.em.stitching.domain.validation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class CallableEndpointValidator implements ConstraintValidator<CallableEndpoint, String> {
+
+    private final Logger log = LoggerFactory.getLogger(CallableEndpointValidator.class);
+
+    @Override
+    public boolean isValid(String url, ConstraintValidatorContext context) {
+
+        try {
+            URL siteURL = new URL(url);
+            HttpURLConnection connection = (HttpURLConnection) siteURL.openConnection();
+            connection.setRequestMethod("POST");
+            connection.setConnectTimeout(3000);
+            connection.connect();
+            int responseCode = connection.getResponseCode();
+            connection.disconnect();
+            return responseCode < 500;
+        } catch (Exception e) {
+            log.error(String.format("Callback %s could not be called", url), e);
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResource.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResource.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.hmcts.reform.em.stitching.domain.enumeration.TaskState;
 import uk.gov.hmcts.reform.em.stitching.rest.errors.BadRequestAlertException;

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResource.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResource.java
@@ -7,7 +7,6 @@ import io.swagger.annotations.ApiResponses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.hmcts.reform.em.stitching.domain.enumeration.TaskState;
 import uk.gov.hmcts.reform.em.stitching.rest.errors.BadRequestAlertException;
@@ -59,7 +58,7 @@ public class DocumentTaskResource {
     public ResponseEntity<DocumentTaskDTO> createDocumentTask(
             @Valid @RequestBody DocumentTaskDTO documentTaskDTO,
             @RequestHeader(value = "Authorization", required = false) String authorisationHeader,
-            HttpServletRequest request, BindingResult bindingResult) throws URISyntaxException {
+            HttpServletRequest request) throws URISyntaxException {
 
         log.info("REST request to save DocumentTask : {}, with headers {}", documentTaskDTO.toString(),
                 Arrays.toString(Collections.toArray(request.getHeaderNames(), new String[]{})));

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResource.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/rest/DocumentTaskResource.java
@@ -7,6 +7,8 @@ import io.swagger.annotations.ApiResponses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.hmcts.reform.em.stitching.domain.enumeration.TaskState;
 import uk.gov.hmcts.reform.em.stitching.rest.errors.BadRequestAlertException;
@@ -15,6 +17,7 @@ import uk.gov.hmcts.reform.em.stitching.service.DocumentTaskService;
 import uk.gov.hmcts.reform.em.stitching.service.dto.DocumentTaskDTO;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -55,10 +58,9 @@ public class DocumentTaskResource {
     @PostMapping("/document-tasks")
     ////@Timed
     public ResponseEntity<DocumentTaskDTO> createDocumentTask(
-            @RequestBody DocumentTaskDTO documentTaskDTO,
+            @Valid @RequestBody DocumentTaskDTO documentTaskDTO,
             @RequestHeader(value = "Authorization", required = false) String authorisationHeader,
-            HttpServletRequest request) throws URISyntaxException {
-
+            HttpServletRequest request, BindingResult bindingResult) throws URISyntaxException {
 
         log.info("REST request to save DocumentTask : {}, with headers {}", documentTaskDTO.toString(),
                 Arrays.toString(Collections.toArray(request.getHeaderNames(), new String[]{})));

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/CallbackDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/CallbackDto.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.reform.em.stitching.service.dto;
 
 import uk.gov.hmcts.reform.em.stitching.domain.enumeration.CallbackState;
+import uk.gov.hmcts.reform.em.stitching.domain.validation.CallableEndpoint;
 
+import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -16,6 +18,8 @@ public class CallbackDto extends AbstractAuditingDTO implements Serializable {
 
     private String failureDescription;
 
+    @NotNull
+    @CallableEndpoint
     private String callbackUrl;
 
     public Long getId() {

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/DocumentTaskDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/service/dto/DocumentTaskDTO.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.em.stitching.service.dto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.gov.hmcts.reform.em.stitching.domain.enumeration.TaskState;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Objects;
@@ -21,6 +22,7 @@ public class DocumentTaskDTO extends AbstractAuditingDTO implements Serializable
 
     private String failureDescription;
 
+    @Valid
     private CallbackDto callback;
 
     @JsonIgnore

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,2 @@
+CallableEndpoint=Connection to the callback URL could not be verified.
+NotNull=required

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpointValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpointValidatorTest.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.reform.em.stitching.domain.validation;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CallableEndpointValidatorTest {
+
+    CallableEndpointValidator callableEndpointValidator = new CallableEndpointValidator();
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(8089);
+
+    @Test
+    public void isValidReturn200() {
+        stubFor(post(urlEqualTo("/my/callback/resource"))
+                .willReturn(aResponse()
+                        .withStatus(200)));
+
+        assertTrue(callableEndpointValidator.isValid("http://localhost:8089/my/callback/resource", null));
+    }
+
+    @Test
+    public void isValidReturn400() {
+        stubFor(post(urlEqualTo("/my/callback/resource"))
+                .willReturn(aResponse()
+                        .withStatus(400)));
+
+        assertTrue(callableEndpointValidator.isValid("http://localhost:8089/my/callback/resource", null));
+    }
+
+    @Test
+    public void isValidReturn500() {
+        stubFor(post(urlEqualTo("/my/callback/resource"))
+                .willReturn(aResponse()
+                        .withStatus(500)));
+
+        assertFalse(callableEndpointValidator.isValid("http://localhost:8089/my/callback/resource", null));
+    }
+
+    @Test
+    public void isValidUnreachable() {
+        assertFalse(callableEndpointValidator.isValid("http://localhost:9999/my/callback/resource", null));
+    }
+
+    @Test
+    public void isValidDomainDoesNotExist() {
+        assertFalse(callableEndpointValidator.isValid("http://thisdomain.surely.does.not.exist12365675.com/my/callback/resource", null));
+    }
+
+    @Test
+    public void isValidDIncorrectUrl() {
+        assertFalse(callableEndpointValidator.isValid("fsduhfiusdhfds", null));
+    }
+
+    @Test
+    public void isValidConnectionReset() {
+
+        stubFor(post(urlEqualTo("/my/callback/resource"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        assertFalse(callableEndpointValidator.isValid("http://localhost:8089/my/callback/resource", null));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpointValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/validation/CallableEndpointValidatorTest.java
@@ -1,69 +1,76 @@
 package uk.gov.hmcts.reform.em.stitching.domain.validation;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-
-import com.github.tomakehurst.wiremock.http.Fault;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.junit.Rule;
+import okhttp3.*;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.em.stitching.Application;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Application.class)
 public class CallableEndpointValidatorTest {
-
-    CallableEndpointValidator callableEndpointValidator = new CallableEndpointValidator();
-
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8089);
 
     @Test
     public void isValidReturn200() {
-        stubFor(post(urlEqualTo("/my/callback/resource"))
-                .willReturn(aResponse()
-                        .withStatus(200)));
+        CallableEndpointValidator callableEndpointValidator = createValidatorWithMockHttp((Interceptor.Chain chain) -> new Response.Builder()
+                .body(ResponseBody.create("", MediaType.parse("plain/text")))
+                .request(chain.request())
+                .message("")
+                .code(200)
+                .protocol(Protocol.HTTP_2)
+                .build());
 
         assertTrue(callableEndpointValidator.isValid("http://localhost:8089/my/callback/resource", null));
     }
 
     @Test
     public void isValidReturn400() {
-        stubFor(post(urlEqualTo("/my/callback/resource"))
-                .willReturn(aResponse()
-                        .withStatus(400)));
+        CallableEndpointValidator callableEndpointValidator = createValidatorWithMockHttp((Interceptor.Chain chain) -> new Response.Builder()
+                .body(ResponseBody.create("", MediaType.parse("plain/text")))
+                .request(chain.request())
+                .message("")
+                .code(400)
+                .protocol(Protocol.HTTP_2)
+                .build());
 
         assertTrue(callableEndpointValidator.isValid("http://localhost:8089/my/callback/resource", null));
     }
 
     @Test
     public void isValidReturn500() {
-        stubFor(post(urlEqualTo("/my/callback/resource"))
-                .willReturn(aResponse()
-                        .withStatus(500)));
+        CallableEndpointValidator callableEndpointValidator = createValidatorWithMockHttp((Interceptor.Chain chain) -> new Response.Builder()
+                .body(ResponseBody.create("", MediaType.parse("plain/text")))
+                .request(chain.request())
+                .message("")
+                .code(500)
+                .protocol(Protocol.HTTP_2)
+                .build());
 
         assertFalse(callableEndpointValidator.isValid("http://localhost:8089/my/callback/resource", null));
     }
 
     @Test
     public void isValidUnreachable() {
+        CallableEndpointValidator callableEndpointValidator = createValidatorWithMockHttp((Interceptor.Chain chain) -> {
+            throw new RuntimeException("x");
+        });
+
         assertFalse(callableEndpointValidator.isValid("http://localhost:9999/my/callback/resource", null));
     }
 
-    @Test
-    public void isValidDomainDoesNotExist() {
-        assertFalse(callableEndpointValidator.isValid("http://thisdomain.surely.does.not.exist12365675.com/my/callback/resource", null));
-    }
+    private CallableEndpointValidator createValidatorWithMockHttp(Interceptor interceptor) {
+        OkHttpClient http = new OkHttpClient
+                .Builder()
+                .addInterceptor(interceptor)
+                .build();
 
-    @Test
-    public void isValidDIncorrectUrl() {
-        assertFalse(callableEndpointValidator.isValid("fsduhfiusdhfds", null));
-    }
-
-    @Test
-    public void isValidConnectionReset() {
-
-        stubFor(post(urlEqualTo("/my/callback/resource"))
-                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
-
-        assertFalse(callableEndpointValidator.isValid("http://localhost:8089/my/callback/resource", null));
+        return new CallableEndpointValidator(http);
     }
 }
+
+
+

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/rest/errors/ExceptionTranslatorIntTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/rest/errors/ExceptionTranslatorIntTest.java
@@ -62,7 +62,7 @@ public class ExceptionTranslatorIntTest {
             .andExpect(jsonPath("$.message").value(ErrorConstants.ERR_VALIDATION))
             .andExpect(jsonPath("$.fieldErrors.[0].objectName").value("testDTO"))
             .andExpect(jsonPath("$.fieldErrors.[0].field").value("test"))
-            .andExpect(jsonPath("$.fieldErrors.[0].message").value("NotNull"));
+            .andExpect(jsonPath("$.fieldErrors.[0].message").value("required"));
     }
 
     @Test


### PR DESCRIPTION
Added the Validator that attempts to connect to the URL using POST and no additional headers or body. The idea is to test if domain can be resolved and connection be created. Any 2xx, 3xx, 4xx is considered OK, but 5xx not.



