### PR TITLE
NPE fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
@@ -33,11 +33,11 @@ public class Bundle extends AbstractAuditingEntity implements SortableBundleItem
     private String stitchStatus;
     private String fileName;
     private String coverpageTemplate;
-    private PageNumberFormat pageNumberFormat = PageNumberFormat.numberOfPages;
+    private PageNumberFormat pageNumberFormat;
     private boolean hasTableOfContents;
     private boolean hasCoversheets;
     private boolean hasFolderCoversheets;
-    private PaginationStyle paginationStyle = PaginationStyle.off;
+    private PaginationStyle paginationStyle;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
@@ -175,7 +175,7 @@ public class Bundle extends AbstractAuditingEntity implements SortableBundleItem
     }
 
     public PaginationStyle getPaginationStyle() {
-        return paginationStyle;
+        return paginationStyle == null ? PaginationStyle.off : paginationStyle;
     }
 
     public void setPaginationStyle(PaginationStyle paginationStyle) {
@@ -191,13 +191,13 @@ public class Bundle extends AbstractAuditingEntity implements SortableBundleItem
     }
 
     public PageNumberFormat getPageNumberFormat() {
-        return pageNumberFormat;
+        return pageNumberFormat == null ? PageNumberFormat.numberOfPages : pageNumberFormat;
     }
 
     public void setPageNumberFormat(PageNumberFormat pageNumberFormat) {
         this.pageNumberFormat = pageNumberFormat;
     }
-  
+
     public String toString() {
         return "Bundle(id=" + this.getId() + ", bundleTitle=" + this.getBundleTitle()
                 + ", description=" + this.getDescription() + ", stitchedDocumentURI=" + this.getStitchedDocumentURI()


### PR DESCRIPTION
Logs show NPE

[{"parsedStack":[{"method":"uk.gov.hmcts.reform.em.stitching.pdf.PDFUtility.addPageNumbers","level":0,"line":68,"fileName":"PDFUtility.java"},

It seems that Bundle default values for property

private PaginationStyle paginationStyle;

is wiped out by hibernate when object is populated from DB.

I moved the logic to getter (same for the other property for good measure)