### PR TITLE
Remove empty folders from bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 out/
 build/
 *.iml
+src/main/generated/
+

--- a/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleFolderScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/stitching/functional/BundleFolderScenarios.java
@@ -6,6 +6,7 @@ import org.assertj.core.util.Files;
 import org.junit.Assert;
 import org.junit.Test;
 import uk.gov.hmcts.reform.em.stitching.service.dto.BundleDTO;
+import uk.gov.hmcts.reform.em.stitching.service.dto.BundleFolderDTO;
 
 import java.io.File;
 import java.io.IOException;
@@ -94,6 +95,36 @@ public class BundleFolderScenarios extends BaseTest {
         final int numFolderCoversheetsPages = 4;
         final int numExtraPages = numContentsPages + numDocCoversheetsPages + numFolderCoversheetsPages;
         final int expectedPages = (getNumPages(document1) * 3) + getNumPages(document2) + numExtraPages;
+        final int actualPages = getNumPages(stitchedFile);
+
+        Files.delete(stitchedFile);
+
+        Assert.assertEquals(expectedPages, actualPages);
+    }
+
+    @Test
+    public void testRemovalOfEmptyFolders() throws IOException, InterruptedException {
+        BundleDTO bundle = testUtil.getTestBundleWithNestedFolders();
+        bundle.setHasFolderCoversheets(true);
+
+        BundleFolderDTO folder = new BundleFolderDTO();
+        folder.setFolderName("Empty folder");
+
+        BundleFolderDTO subFolder = new BundleFolderDTO();
+        subFolder.setFolderName("Empty sub-folder");
+
+        folder.getFolders().add(subFolder);
+        bundle.getFolders().set(0, folder); // replace the first folder
+
+        final Response response = testUtil.processBundle(bundle);
+        final String stitchedDocumentUri = response.getBody().jsonPath().getString(STITCHED_DOCUMENT_URI);
+        final File stitchedFile = testUtil.downloadDocument(stitchedDocumentUri);
+
+        final int numContentsPages = 1;
+        final int numDocCoversheetsPages = 1;
+        final int numFolderCoversheetsPages = 1;
+        final int numExtraPages = numContentsPages + numDocCoversheetsPages + numFolderCoversheetsPages;
+        final int expectedPages = getNumPages(document2) + numExtraPages;
         final int actualPages = getNumPages(stitchedFile);
 
         Files.delete(stitchedFile);

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/Bundle.java
@@ -88,6 +88,7 @@ public class Bundle extends AbstractAuditingEntity implements SortableBundleItem
     public Stream<SortableBundleItem> getSortedItems() {
         return Stream
             .<SortableBundleItem>concat(documents.stream(), folders.stream())
+            .filter(i -> i.getSortedDocuments().count() > 0)
             .sorted(Comparator.comparingInt(SortableBundleItem::getSortIndex));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/BundleContainer.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/BundleContainer.java
@@ -11,7 +11,7 @@ public interface BundleContainer {
         return Stream.concat(
             getFolders().stream(),
             getFolders().stream().flatMap(BundleContainer::getNestedFolders)
-        );
+        ).filter(f -> !f.getDocuments().isEmpty());
     }
 
     List<BundleFolder> getFolders();

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/BundleFolder.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/domain/BundleFolder.java
@@ -56,6 +56,7 @@ public class BundleFolder extends AbstractAuditingEntity implements Serializable
     public Stream<SortableBundleItem> getSortedItems() {
         return Stream
             .<SortableBundleItem>concat(documents.stream(), folders.stream())
+            .filter(i -> i.getSortedDocuments().count() > 0)
             .sorted(Comparator.comparingInt(SortableBundleItem::getSortIndex));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/BundleTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/domain/BundleTest.java
@@ -146,6 +146,53 @@ public class BundleTest {
     }
 
     @Test
+    public void testRemovalOfEmptyFolders() {
+        Bundle bundle = BundleTest.getTestBundle();
+        bundle.setDocuments(new ArrayList<>());
+        bundle.setFolders(new ArrayList<>());
+        bundle.getDocuments().add(getBundleDocument(1));
+
+        BundleFolder folder1 = getBundleFolder(2);
+        folder1.getDocuments().add(getBundleDocument(1));
+        folder1.getDocuments().add(getBundleDocument(2));
+
+        BundleFolder folder2 = getBundleFolder(3);
+        BundleFolder folder3 = getBundleFolder(1);
+
+        bundle.getFolders().add(folder1);
+        bundle.getFolders().add(folder2);
+        folder2.getFolders().add(folder3);
+
+        final long result = bundle.getSortedItems().count();
+        final int expected = 2; //one document, one folder
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testGetNestedFolders() {
+        Bundle bundle = BundleTest.getTestBundle();
+        bundle.setDocuments(new ArrayList<>());
+        bundle.setFolders(new ArrayList<>());
+
+        BundleFolder folder1 = getBundleFolder(2);
+        folder1.getDocuments().add(getBundleDocument(1));
+        folder1.getDocuments().add(getBundleDocument(2));
+
+        BundleFolder folder2 = getBundleFolder(3);
+        BundleFolder folder3 = getBundleFolder(1);
+
+        bundle.getFolders().add(folder1);
+        bundle.getFolders().add(folder2);
+        folder2.getFolders().add(folder3);
+
+        final long result = bundle.getNestedFolders().count();
+        final int expected = 1; //folder 2 should be omitted
+
+        assertEquals(expected, result);
+    }
+
+    @Test
     public void getFileName() {
         Bundle bundle = new Bundle();
         assertNull(bundle.getFileName());


### PR DESCRIPTION
Part of EM-2078 stipulates that only populated folders have coversheets. Logically it follows that they should not appear in the table of contents either. This change covers both.