### PR TITLE
EM-2419 Add space after a folder on TOC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,6 @@ project.tasks['sonarqube'].dependsOn jacocoTestReport
 sonarqube {
     properties {
         property "sonar.projectName", "${rootProject.name}"
-        property "sonar.projectKey", "uk.gov.hmcts.reform:em"
         property "sonar.coverage.jacoco.xmlReportPaths", "${jacocoTestReport.reports.xml.destination.path}"
         property "sonar.exclusions", coverageExclusionList.join(", ")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -259,11 +259,6 @@ def coverageExclusionList = [
     '**uk/gov/hmcts/reform/em/stitching/service/dto/*',
 ]
 
-jacoco {
-    toolVersion = '0.7.9' // jacocoMavenPluginVersion
-    reportsDir = file("$buildDir/reports/jacoco")
-}
-
 jacocoTestReport {
     executionData(test)
 
@@ -274,18 +269,15 @@ jacocoTestReport {
         xml.destination file("${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
     }
 
-    afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: coverageExclusionList)
-        })
-    }
 }
+
+project.tasks['sonarqube'].dependsOn jacocoTestReport
 
 sonarqube {
     properties {
         property "sonar.projectName", "${rootProject.name}"
-        property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco/test.exec"
-        property "sonar.dependencyCheck.reportPath", "${project.buildDir}/reports/dependency-check-report.xml"
+        property "sonar.projectKey", "uk.gov.hmcts.reform:em"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${jacocoTestReport.reports.xml.destination.path}"
         property "sonar.exclusions", coverageExclusionList.join(", ")
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -86,6 +86,10 @@ public class PDFMerger {
                 }
             }
 
+            if (tableOfContents != null) {
+                tableOfContents.setEndOfFolder(true);
+            }
+
             return currentPageNumber;
         }
 
@@ -154,6 +158,7 @@ public class PDFMerger {
         private final PDDocument document;
         private final Bundle bundle;
         private int numDocumentsAdded = 0;
+        private boolean endOfFolder = false;
 
         private TableOfContents(PDDocument document, Bundle bundle) throws IOException {
             this.document = document;
@@ -175,29 +180,38 @@ public class PDFMerger {
         }
 
         public void addDocument(String documentTitle, int pageNumber, int noOfPages) throws IOException {
-            final float yOffset = getVerticalOffset();
-            final PDPage destination = document.getPage(pageNumber);
-            final String text = documentTitle;
+            float yOffset = getVerticalOffset();
 
-            addLink(document, getPage(), destination, text, yOffset,PDType1Font.HELVETICA,12);
+            // add an extra space after a folder so the document doesn't look like it's in the folder
+            if (endOfFolder) {
+                addText(document, getPage(), " ", 50, yOffset, PDType1Font.HELVETICA_BOLD, 13);
+                yOffset += LINE_HEIGHT;
+                numDocumentsAdded++;
+            }
+
+            final PDPage destination = document.getPage(pageNumber);
+
+            addLink(document, getPage(), destination, documentTitle, yOffset, PDType1Font.HELVETICA, 12);
 
             String pageNo = bundle.getPageNumberFormat().getPageNumber(pageNumber, noOfPages);
 
-            addText(document, getPage(), pageNo, 480, yOffset - 3, PDType1Font.HELVETICA,12);
+            addText(document, getPage(), pageNo, 480, yOffset - 3, PDType1Font.HELVETICA, 12);
             numDocumentsAdded++;
+            endOfFolder = false;
         }
 
         public void addFolder(String title, int pageNumber) throws IOException {
             final PDPage destination = document.getPage(pageNumber);
             float yyOffset = getVerticalOffset();
 
-            addText(document, getPage(), " ", 50, yyOffset, PDType1Font.HELVETICA_BOLD,13);
+            addText(document, getPage(), " ", 50, yyOffset, PDType1Font.HELVETICA_BOLD, 13);
             yyOffset += LINE_HEIGHT;
-            addLink(document, getPage(), destination, title, yyOffset, PDType1Font.HELVETICA_BOLD,13);
+            addLink(document, getPage(), destination, title, yyOffset, PDType1Font.HELVETICA_BOLD, 13);
             yyOffset += LINE_HEIGHT;
-            addText(document, getPage(), " ", 50, yyOffset, PDType1Font.HELVETICA_BOLD,13);
+            addText(document, getPage(), " ", 50, yyOffset, PDType1Font.HELVETICA_BOLD, 13);
 
             numDocumentsAdded += 3;
+            endOfFolder = false;
         }
 
         private float getVerticalOffset() {
@@ -219,5 +233,8 @@ public class PDFMerger {
             return Math.max(1, numPages);
         }
 
+        public void setEndOfFolder(boolean value) {
+            endOfFolder = value;
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -180,22 +180,22 @@ public class PDFMerger {
         }
 
         public void addDocument(String documentTitle, int pageNumber, int noOfPages) throws IOException {
-            float yOffset = getVerticalOffset();
+            float yyOffset = getVerticalOffset();
 
             // add an extra space after a folder so the document doesn't look like it's in the folder
             if (endOfFolder) {
-                addText(document, getPage(), " ", 50, yOffset, PDType1Font.HELVETICA_BOLD, 13);
-                yOffset += LINE_HEIGHT;
+                addText(document, getPage(), " ", 50, yyOffset, PDType1Font.HELVETICA_BOLD, 13);
+                yyOffset += LINE_HEIGHT;
                 numDocumentsAdded++;
             }
 
             final PDPage destination = document.getPage(pageNumber);
 
-            addLink(document, getPage(), destination, documentTitle, yOffset, PDType1Font.HELVETICA, 12);
+            addLink(document, getPage(), destination, documentTitle, yyOffset, PDType1Font.HELVETICA, 12);
 
             String pageNo = bundle.getPageNumberFormat().getPageNumber(pageNumber, noOfPages);
 
-            addText(document, getPage(), pageNo, 480, yOffset - 3, PDType1Font.HELVETICA, 12);
+            addText(document, getPage(), pageNo, 480, yyOffset - 3, PDType1Font.HELVETICA, 12);
             numDocumentsAdded++;
             endOfFolder = false;
         }

--- a/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMergerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMergerTest.java
@@ -218,6 +218,58 @@ public class PDFMergerTest {
     }
 
     @Test
+    public void testAddSpaceAfterEndOfFolder() throws IOException, DocumentTaskProcessingException {
+        bundle.setHasTableOfContents(true);
+        bundle.setHasFolderCoversheets(true);
+        bundle.setDocuments(new ArrayList<>());
+        documents = new HashMap<>();
+
+        BundleDocument bundleDocument = new BundleDocument();
+        bundleDocument.setDocTitle("Bundle Doc 1");
+        bundleDocument.setSortIndex(1);
+        bundle.getDocuments().add(bundleDocument);
+        documents.put(bundleDocument, FILE_1);
+
+        BundleFolder folder = new BundleFolder();
+        folder.setFolderName("Folder 1");
+        folder.setSortIndex(2);
+        bundle.getFolders().add(folder);
+
+        BundleDocument folderDocument = new BundleDocument();
+        folderDocument.setDocTitle("Folder Doc 1");
+        folder.getDocuments().add(folderDocument);
+        documents.put(folderDocument, FILE_1);
+
+        BundleDocument bundleDocument2 = new BundleDocument();
+        bundleDocument2.setDocTitle("Bundle Doc 2");
+        bundleDocument2.setSortIndex(3);
+        bundle.getDocuments().add(bundleDocument2);
+        documents.put(bundleDocument2, FILE_1);
+
+        PDFMerger merger = new PDFMerger();
+        File stitched = merger.merge(bundle, documents, null);
+
+        PDDocument doc1 = PDDocument.load(FILE_1);
+        PDDocument stitchedDocument = PDDocument.load(stitched);
+
+        final int documentPages = doc1.getNumberOfPages() * 3;
+        final int additionalSpaceAfterEndOfFolder = 1;
+        final int folderItems = 3;
+        final int documentItems = 3;
+        final int tocItems = documentItems + folderItems + additionalSpaceAfterEndOfFolder;
+        final int tocPages = (int) Math.ceil((double) tocItems / 40);
+        final int folderPages = 1;
+        final int expectedPages = documentPages + tocPages + folderPages;
+        final int actualPages = stitchedDocument.getNumberOfPages();
+
+        doc1.close();
+        stitchedDocument.close();
+
+        assertEquals(expectedPages, actualPages);
+    }
+
+
+    @Test
     public void testPageNumbersPrintedOnCorrectPagesWithPaginationOptionSelected() throws IOException, DocumentTaskProcessingException {
         bundle.setHasTableOfContents(true);
         bundle.setDocuments(new ArrayList<>());


### PR DESCRIPTION
This change adds a space (line break) on the table of contents page inbetween the end of a folder and the next document. 