### PR TITLE
catching the issue with the corrupt pdf

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -144,6 +144,7 @@ public class PDFMerger {
             }
             catch (IndexOutOfBoundsException e) {
                 newDoc.getDocumentCatalog().setStructureTreeRoot(new PDStructureTreeRoot());
+                log.info("Setting new PDF structure tree of " + newDoc.getDocumentInformation().getTitle());
                 merger.appendDocument(document, newDoc);
             }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -141,8 +141,7 @@ public class PDFMerger {
 
             try {
                 merger.appendDocument(document, newDoc);
-            }
-            catch (IndexOutOfBoundsException e) {
+            } catch (IndexOutOfBoundsException e) {
                 newDoc.getDocumentCatalog().setStructureTreeRoot(new PDStructureTreeRoot());
                 log.info("Setting new PDF structure tree of " + item.getTitle());
                 merger.appendDocument(document, newDoc);

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -144,7 +144,7 @@ public class PDFMerger {
             }
             catch (IndexOutOfBoundsException e) {
                 newDoc.getDocumentCatalog().setStructureTreeRoot(new PDStructureTreeRoot());
-                log.info("Setting new PDF structure tree of " + newDoc.getDocumentInformation().getTitle());
+                log.info("Setting new PDF structure tree of " + item.getTitle());
                 merger.appendDocument(document, newDoc);
             }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/stitching/pdf/PDFMerger.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.em.stitching.pdf;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageDestination;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
@@ -138,7 +139,13 @@ public class PDFMerger {
             final PDDocumentOutline newDocOutline = newDoc.getDocumentCatalog().getDocumentOutline();
             newDoc.getDocumentCatalog().setDocumentOutline(null);
 
-            merger.appendDocument(document, newDoc);
+            try {
+                merger.appendDocument(document, newDoc);
+            }
+            catch (IndexOutOfBoundsException e) {
+                newDoc.getDocumentCatalog().setStructureTreeRoot(new PDStructureTreeRoot());
+                merger.appendDocument(document, newDoc);
+            }
 
             if (bundle.getPaginationStyle() != PaginationStyle.off) {
                 addPageNumbers(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-2614


### Change description ###
issue with a pdf where it would fail due to the pdf structure tree which my fix was to catch the issue and set the structure tree as a new object.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
