### PR TITLE
EM-2807 Removed the pdf from the exclusion list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -260,7 +260,6 @@ def coverageExclusionList = [
     '**uk/gov/hmcts/reform/em/stitching/info/*',
     '**uk/gov/hmcts/reform/em/stitching/service/mapper/*',
     '**uk/gov/hmcts/reform/em/stitching/domain/*',
-    '**uk/gov/hmcts/reform/em/stitching/pdf/*',
     '**uk/gov/hmcts/reform/em/stitching/service/dto/*',
     '**uk/gov/hmcts/reform/em/stitching/config/security/*',
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-2807


### Change description ###
changes to bring back uk/gov/hmcts/reform/em/stitching/pdf for sonar coverage



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
